### PR TITLE
feat: Add fractional insert mode to LTX Sequencer

### DIFF
--- a/js/ltx_sequencer.js
+++ b/js/ltx_sequencer.js
@@ -150,6 +150,8 @@ app.registerExtension({
                     shouldBeVisible = (mode === "frames");
                 } else if (w.name.startsWith("insert_second_")) {
                     shouldBeVisible = (mode === "seconds");
+                } else if (w.name.startsWith("insert_fraction_")) {
+                    shouldBeVisible = (mode === "fractional");
                 }
                 
                 const isHidden = (w.type === "hidden");
@@ -177,7 +179,10 @@ app.registerExtension({
             this._hookStaticWidgets();
 
             const isInitialLoad = this._currentImageCount === -1;
-            if (this._currentImageCount === count && !isInitialLoad) return;
+            if (this._currentImageCount === count && !isInitialLoad) {
+                this._updateVisibility();
+                return;
+            }
             this._currentImageCount = count;
 
             const initialWidth = this.size[0];
@@ -201,6 +206,7 @@ app.registerExtension({
                 this.widgets = this.widgets.filter(w => 
                     !w.name.startsWith("insert_frame_") && 
                     !w.name.startsWith("insert_second_") && 
+                    !w.name.startsWith("insert_fraction_") &&
                     !w.name.startsWith("strength_") &&
                     !w.name.startsWith("header_")
                 );
@@ -246,6 +252,7 @@ app.registerExtension({
 
                 addSyncedWidget("number", `insert_frame_${i}`, 0, { min: -9999, max: 9999, step: 10, precision: 0 });
                 addSyncedWidget("number", `insert_second_${i}`, 0.0, { min: 0.0, max: 9999.0, step: 0.1, precision: 2 });
+                addSyncedWidget("number", `insert_fraction_${i}`, 0.0, { min: 0.0, max: 1.0, step: 0.01, precision: 3 });
                 addSyncedWidget("number", `strength_${i}`, 1.0, { min: 0.0, max: 1.0, step: 0.01 });
             }
 
@@ -300,11 +307,15 @@ app.registerExtension({
             strictArray.push(this.properties["num_images"] !== undefined ? this.properties["num_images"] : 1);
             strictArray.push(this.properties["insert_mode"] !== undefined ? this.properties["insert_mode"] : "frames");
             strictArray.push(this.properties["frame_rate"] !== undefined ? this.properties["frame_rate"] : 24);
-            
+
             for (let i = 1; i <= 50; i++) {
                 strictArray.push(this.properties[`insert_frame_${i}`] !== undefined ? this.properties[`insert_frame_${i}`] : 0);
                 strictArray.push(this.properties[`insert_second_${i}`] !== undefined ? this.properties[`insert_second_${i}`] : 0.0);
                 strictArray.push(this.properties[`strength_${i}`] !== undefined ? this.properties[`strength_${i}`] : 1.0);
+            }
+
+            for (let i = 1; i <= 50; i++) {
+                strictArray.push(this.properties[`insert_fraction_${i}`] !== undefined ? this.properties[`insert_fraction_${i}`] : 0.0);
             }
             info.widgets_values = strictArray;
         };

--- a/ltx_sequencer.py
+++ b/ltx_sequencer.py
@@ -1,4 +1,4 @@
-from comfy_extras.nodes_lt import get_noise_mask, LTXVAddGuide
+from comfy_extras.nodes_lt import get_keyframe_idxs, get_noise_mask, LTXVAddGuide
 import torch
 import comfy.utils
 from comfy_api.latest import io
@@ -17,7 +17,7 @@ class LTXSequencer(LTXVAddGuide):
         inputs.append(io.Int.Input("num_images", default=1, min=0, max=50, step=1, display_name="images_loaded", tooltip="Select how many index/strength widgets to configure."))
         
         # New global settings widgets
-        inputs.append(io.Combo.Input("insert_mode", options=["frames", "seconds"], default="frames", tooltip="Select the method for determining insertion points."))
+        inputs.append(io.Combo.Input("insert_mode", options=["frames", "seconds", "fractional"], default="frames", tooltip="Select the method for determining insertion points."))
         inputs.append(io.Int.Input("frame_rate", default=24, min=1, max=120, step=1, tooltip="Video FPS (used for calculating second insertions)."))
 
         for i in range(1, 51):  # 1 to 50 images
@@ -51,11 +51,24 @@ class LTXSequencer(LTXVAddGuide):
                 ),
             ])
 
+        for i in range(1, 51):  # Appended to preserve legacy widgets_values order.
+            inputs.extend([
+                io.Float.Input(
+                    f"insert_fraction_{i}",
+                    default=0.0,
+                    min=0.0,
+                    max=1.0,
+                    step=0.01,
+                    tooltip=f"Fractional clip position for image {i}. 0.0 is the first frame, 1.0 is the final frame.",
+                    optional=True,
+                ),
+            ])
+
         return io.Schema(
             node_id="LTXSequencer",
             display_name="LTX Sequencer",
             category="WhatDreamsCost",
-            description="Add multiple guide images at specified frame indices or seconds with strengths. Number of widgets is dynamically configured.",
+            description="Add multiple guide images at specified frame indices, seconds, or fractional clip positions with strengths. Number of widgets is dynamically configured.",
             inputs=inputs,
             outputs=[
                 io.Conditioning.Output(display_name="positive"),
@@ -84,10 +97,20 @@ class LTXSequencer(LTXVAddGuide):
 
         _, _, latent_length, latent_height, latent_width = latent_image.shape
         batch_size = multi_input.shape[0] if multi_input is not None else 0
+        temporal_upscale = scale_factors[0] if scale_factors else None
 
         # Retrieve selected insertion settings
         insert_mode = kwargs.get("insert_mode", "frames")
         frame_rate = kwargs.get("frame_rate", 24)
+        _, initial_num_keyframes = get_keyframe_idxs(positive)
+        initial_latent_count = max(1, latent_length - initial_num_keyframes)
+        if callable(temporal_upscale):
+            video_frame_count = temporal_upscale(initial_latent_count)
+        elif isinstance(temporal_upscale, (int, float)):
+            video_frame_count = max(1, int((initial_latent_count - 1) * temporal_upscale + 1))
+        else:
+            video_frame_count = initial_latent_count
+        video_frame_count = max(1, int(video_frame_count))
 
         # Process inputs up to num_images, extracting dynamic frame/strength values from kwargs
         for i in range(1, num_images + 1):
@@ -107,6 +130,11 @@ class LTXSequencer(LTXVAddGuide):
                 sec = kwargs.get(f"insert_second_{i}")
                 if sec is not None:
                     f_idx = int(sec * frame_rate)
+            elif insert_mode == "fractional":
+                fraction = kwargs.get(f"insert_fraction_{i}")
+                if fraction is not None:
+                    fraction = max(0.0, min(float(fraction), 1.0))
+                    f_idx = -1 if fraction >= 1.0 else round(fraction * (video_frame_count - 1))
 
             if f_idx is None:
                 continue
@@ -116,7 +144,9 @@ class LTXSequencer(LTXVAddGuide):
             # Execution logic mirrored from LTXVAddGuideMulti
             image_1, t = cls.encode(vae, latent_width, latent_height, img, scale_factors)
 
-            frame_idx, latent_idx = cls.get_latent_index(positive, latent_length, len(image_1), f_idx, scale_factors)
+            _, current_num_keyframes = get_keyframe_idxs(positive)
+            effective_latent_length = latent_length + current_num_keyframes
+            frame_idx, latent_idx = cls.get_latent_index(positive, effective_latent_length, len(image_1), f_idx, scale_factors)
             assert latent_idx + t.shape[2] <= latent_length, "Conditioning frames exceed the length of the latent sequence."
 
             positive, negative, latent_image, noise_mask = cls.append_keyframe(


### PR DESCRIPTION
## Summary

Adds a new `fractional` insert mode to the LTX Sequencer node.

This lets users place guide images by normalized clip position instead of absolute frames or seconds:

- `0.0` = first frame
- `0.5` = halfway through the clip
- `1.0` = final frame, matching existing `insert_frame = -1` behavior

## Changes

- Added `fractional` to the `insert_mode` options.
- Added per-image `insert_fraction_N` inputs with range `0.0` to `1.0`.
- Updated the frontend dynamic widget logic so:
  - `frames` shows `insert_frame_*`
  - `seconds` shows `insert_second_*`
  - `fractional` shows `insert_fraction_*`
- Preserved legacy `widgets_values` ordering for existing workflows by appending fraction inputs after the existing frame/second/strength fields.
- Fixed Sequencer negative frame placement so `insert_frame = -1` resolves to the actual final frame of the original clip, even after earlier guide keyframes have been appended.
- This also makes `fractional = 1.0` resolve to the true final frame, since fractional final placement maps through the existing `-1` behavior.
