### PR TITLE
Update ltx_sequencer.js - strength field buttons not working

### DIFF
--- a/js/ltx_sequencer.js
+++ b/js/ltx_sequencer.js
@@ -246,7 +246,7 @@ app.registerExtension({
 
                 addSyncedWidget("number", `insert_frame_${i}`, 0, { min: -9999, max: 9999, step: 10, precision: 0 });
                 addSyncedWidget("number", `insert_second_${i}`, 0.0, { min: 0.0, max: 9999.0, step: 0.1, precision: 2 });
-                addSyncedWidget("number", `strength_${i}`, 1.0, { min: 0.0, max: 1.0, step: 0.01 });
+                addSyncedWidget("number", `strength_${i}`, 1.0, { min: 0.0, max: 1.0, step: 0.01, precision: 2 });
             }
 
             this._updateVisibility();


### PR DESCRIPTION
The strength field buttons have been corrected. 
They weren't working.