### PR TITLE
fix: support both raw AudioVAE and ComfyUI VAE wrapper in get_empty_latent Issue #43

### DIFF
--- a/ltx_director.py
+++ b/ltx_director.py
@@ -584,9 +584,11 @@ class LTXDirector(io.ComfyNode):
         if audio_vae is not None:
             # Helper to generate empty latent
             def get_empty_latent():
+                # Support both raw AudioVAE objects and ComfyUI VAE wrappers
+                inner = getattr(audio_vae, "first_stage_model", audio_vae)
                 z_channels = audio_vae.latent_channels
-                audio_freq = audio_vae.first_stage_model.latent_frequency_bins
-                num_audio_latents = audio_vae.first_stage_model.num_of_latents_from_frames(ltxv_length, float(frame_rate))
+                audio_freq = inner.latent_frequency_bins
+                num_audio_latents = inner.num_of_latents_from_frames(ltxv_length, float(frame_rate))
                 audio_latents = torch.zeros(
                     (1, z_channels, num_audio_latents, audio_freq),
                     device=comfy.model_management.intermediate_device(),
@@ -629,7 +631,8 @@ class LTXDirector(io.ComfyNode):
                     audio_latent = get_empty_latent()
                     log.info("[PromptRelay] Auto-generated empty audio latent.")
                 except Exception as e:
-                    log.warning("[PromptRelay] Could not generate empty audio latent: %s", e)
+                    log.error("[PromptRelay] Could not generate empty audio latent: %s", e)
+                    raise e
 
         return io.NodeOutput(patched, conditioning, latent, audio_latent, guide_data, float(frame_rate), audio_out)
 


### PR DESCRIPTION
Fixes #43

When using VAELoaderKJ from KJNodes to load the Audio VAE, the object
returned can be a raw AudioVAE (no `first_stage_model` attribute) instead
of a ComfyUI VAE wrapper. The previous code assumed `first_stage_model`
always existed, causing an AttributeError silently swallowed, leaving
audio_latent as {} which then caused KeyError: 'samples' in LTXVConcatAVLatent.

Fix: use getattr(audio_vae, "first_stage_model", audio_vae) to support both cases.
Also changed the silent warning on empty latent failure to raise the exception
so errors surface properly instead of causing cryptic downstream failures.