### PR TITLE
fix: handle custom audio encode for wrapped and raw AudioVAE

### DIFF
--- a/ltx_director.py
+++ b/ltx_director.py
@@ -584,9 +584,11 @@ class LTXDirector(io.ComfyNode):
         if audio_vae is not None:
             # Helper to generate empty latent
             def get_empty_latent():
+                # Support both raw AudioVAE objects and ComfyUI VAE wrappers.
+                inner = getattr(audio_vae, "first_stage_model", audio_vae)
                 z_channels = audio_vae.latent_channels
-                audio_freq = audio_vae.first_stage_model.latent_frequency_bins
-                num_audio_latents = audio_vae.first_stage_model.num_of_latents_from_frames(ltxv_length, float(frame_rate))
+                audio_freq = inner.latent_frequency_bins
+                num_audio_latents = inner.num_of_latents_from_frames(ltxv_length, float(frame_rate))
                 audio_latents = torch.zeros(
                     (1, z_channels, num_audio_latents, audio_freq),
                     device=comfy.model_management.intermediate_device(),
@@ -644,7 +646,8 @@ class LTXDirector(io.ComfyNode):
                     audio_latent = get_empty_latent()
                     log.info("[PromptRelay] Auto-generated empty audio latent.")
                 except Exception as e:
-                    log.warning("[PromptRelay] Could not generate empty audio latent: %s", e)
+                    log.error("[PromptRelay] Could not generate empty audio latent: %s", e)
+                    raise e
 
         return io.NodeOutput(patched, conditioning, latent, audio_latent, guide_data, float(frame_rate), audio_out)
 

--- a/ltx_director.py
+++ b/ltx_director.py
@@ -597,8 +597,23 @@ class LTXDirector(io.ComfyNode):
                 try:
                     if audio_out is not None:
                         # 1. Encode audio waveform into latent space
-                        # VAE expects shape (batch, samples, channels), so we move dim 1 (channels) to the end
-                        latent_samples = audio_vae.encode(audio_out["waveform"].movedim(1, -1))
+                        waveform = audio_out["waveform"]
+                        if waveform.ndim == 2:
+                            waveform = waveform.unsqueeze(0)
+                        if waveform.ndim != 3:
+                            raise ValueError(
+                                f"Expected custom audio waveform with 2 or 3 dims, got shape {tuple(waveform.shape)}"
+                            )
+
+                        # Wrapped ComfyUI VAE expects (batch, samples, channels);
+                        # raw AudioVAE expects a dict with waveform in (batch, channels, samples).
+                        if hasattr(audio_vae, "first_stage_model"):
+                            latent_samples = audio_vae.encode(waveform.movedim(1, -1))
+                        else:
+                            latent_samples = audio_vae.encode({
+                                "waveform": waveform,
+                                "sample_rate": audio_out["sample_rate"],
+                            })
                         
                         if latent_samples.numel() == 0:
                             raise ValueError("Encoded audio latent is empty (0 elements).")


### PR DESCRIPTION
This fixes an IndexError in LTXDirector when custom audio is enabled.

Root cause:
The custom audio encode path assumed a single encode API and tensor layout. In practice, audio_vae can be either:

a wrapped ComfyUI VAE (expects tensor in batch, samples, channels), or
a raw AudioVAE (expects a dict with waveform/sample_rate, waveform in batch, channels, samples).
What changed:

Normalize waveform rank for custom audio (2D to 3D when needed).
Branch encode call by VAE type:
wrapped VAE: encode(waveform movedim channels to last)
raw AudioVAE: encode({ waveform, sample_rate })
Result:

Prevents tensor-dimension mismatch and IndexError in custom audio mode across both VAE object types.