### PR TITLE
Add built-in AI Prompt Writer to LTX Director (GGUF + style presets + per-segment hints)

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -6,6 +6,8 @@ from .load_audio_ui import LoadAudioUI
 from .load_video_ui import LoadVideoUI
 from .ltx_director import LTXDirector
 from .ltx_director_guide import LTXDirectorGuide
+from .ltx_prompt_writer import register_routes
+register_routes()
 from comfy_api.latest import ComfyExtension, io
 from typing_extensions import override
 

--- a/example_workflows/LTX Director + LTX2EasyPrompt Example.json
+++ b/example_workflows/LTX Director + LTX2EasyPrompt Example.json
@@ -1,0 +1,4199 @@
+{
+  "id": "c92620ea-60b4-4f41-a78f-621383a62c2b",
+  "revision": 0,
+  "last_node_id": 108,
+  "last_link_id": 261,
+  "nodes": [
+    {
+      "id": 105,
+      "type": "LoadImage",
+      "pos": [
+        430,
+        3870
+      ],
+      "size": [
+        210,
+        130
+      ],
+      "flags": {},
+      "order": 1,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": [
+            259
+          ]
+        },
+        {
+          "name": "MASK",
+          "type": "MASK",
+          "links": []
+        }
+      ],
+      "title": "Reference Image",
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.19.3",
+        "Node name for S&R": "LoadImage",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "example.png",
+        "image"
+      ],
+      "color": "#222",
+      "bgcolor": "#000"
+    },
+    {
+      "id": 106,
+      "type": "LTX2VisionDescribe",
+      "pos": [
+        430,
+        4030
+      ],
+      "size": [
+        270,
+        170
+      ],
+      "flags": {},
+      "order": 2,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "image",
+          "type": "IMAGE",
+          "link": 259
+        }
+      ],
+      "outputs": [
+        {
+          "name": "scene_context",
+          "type": "STRING",
+          "links": [
+            260
+          ]
+        }
+      ],
+      "title": "Vision Describe",
+      "properties": {
+        "Node name for S&R": "LTX2VisionDescribe",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        true,
+        "Qwen2.5-VL-3B — Fast (huihui abliterated)",
+        false,
+        ""
+      ],
+      "color": "#222",
+      "bgcolor": "#000"
+    },
+    {
+      "id": 107,
+      "type": "LTX2PromptArchitectQwen",
+      "pos": [
+        430,
+        4240
+      ],
+      "size": [
+        270,
+        620
+      ],
+      "flags": {},
+      "order": 3,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "audio_input",
+          "type": "AUDIO",
+          "link": null
+        },
+        {
+          "name": "🖼 scene context",
+          "type": "STRING",
+          "widget": {
+            "name": "🖼 scene context"
+          },
+          "link": 260
+        }
+      ],
+      "outputs": [
+        {
+          "name": "PROMPT",
+          "type": "STRING",
+          "links": [
+            261
+          ]
+        },
+        {
+          "name": "PREVIEW",
+          "type": "STRING",
+          "links": []
+        },
+        {
+          "name": "NEG_PROMPT",
+          "type": "STRING",
+          "links": []
+        }
+      ],
+      "title": "Prompt Architect",
+      "properties": {
+        "Node name for S&R": "LTX2PromptArchitectQwen",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        false,
+        true,
+        true,
+        "describe what should happen in this video segment",
+        "0.8 - Balanced Professional",
+        "None — LLM decides",
+        "None — LLM decides",
+        "None — let the LLM decide",
+        "None — LLM decides",
+        -1,
+        "randomize",
+        0,
+        "",
+        "",
+        "None — detect from prompt",
+        "None — LLM decides",
+        false,
+        false,
+        192,
+        0,
+        0,
+        "huihui-ai/Huihui-Qwen3.5-9B-abliterated",
+        "",
+        false,
+        false
+      ],
+      "color": "#222",
+      "bgcolor": "#000"
+    },
+    {
+      "id": 108,
+      "type": "MarkdownNote",
+      "pos": [
+        430,
+        3730
+      ],
+      "size": [
+        270,
+        120
+      ],
+      "flags": {},
+      "order": 0,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [],
+      "title": "LTX2EasyPrompt Integration",
+      "properties": {
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "## LTX2EasyPrompt Integration\n\nThis chain generates an LTX-2.3 optimised prompt from a reference image:\n\n1. **Load Image** → pick your reference frame\n2. **Vision Describe** (Qwen2.5-VL) → analyses the image into a `scene_context`\n3. **Prompt Architect** (Qwen3.5) → expands to a full cinematic LTX prompt\n4. Prompt feeds into **LTX Director** `local_prompts`\n\nRequires: <https://github.com/LoRa-Daddy/LTX2EasyPrompt-LD>"
+      ],
+      "color": "#322",
+      "bgcolor": "#533"
+    },
+    {
+      "id": 96,
+      "type": "739520a4-718f-490f-87d1-34ffbca98e3f",
+      "pos": [
+        3000,
+        4620
+      ],
+      "size": [
+        210,
+        130
+      ],
+      "flags": {},
+      "order": 9,
+      "mode": 0,
+      "inputs": [
+        {
+          "label": "audio_latent",
+          "name": "samples",
+          "type": "LATENT",
+          "link": 244
+        },
+        {
+          "label": "audio_vae",
+          "name": "audio_vae",
+          "type": "VAE",
+          "link": 245
+        },
+        {
+          "label": "video_latent",
+          "name": "samples_1",
+          "type": "LATENT",
+          "link": 246
+        },
+        {
+          "label": "video_vae",
+          "name": "vae",
+          "type": "VAE",
+          "link": 247
+        },
+        {
+          "name": "fps",
+          "type": "FLOAT",
+          "widget": {
+            "name": "fps"
+          },
+          "link": 248
+        }
+      ],
+      "outputs": [
+        {
+          "name": "VIDEO",
+          "type": "VIDEO",
+          "links": [
+            249
+          ]
+        }
+      ],
+      "properties": {
+        "proxyWidgets": [
+          [
+            "17",
+            "fps"
+          ]
+        ],
+        "cnr_id": "comfy-core",
+        "ver": "0.19.3",
+        "ue_properties": {
+          "widget_ue_connectable": {
+            "fps": true
+          },
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [],
+      "color": "#222",
+      "bgcolor": "#000"
+    },
+    {
+      "id": 92,
+      "type": "MarkdownNote",
+      "pos": [
+        1430,
+        4220
+      ],
+      "size": [
+        400,
+        530
+      ],
+      "flags": {},
+      "order": 4,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [],
+      "title": "FAQ",
+      "properties": {
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "# FAQ\n\n**How do I use this??**\n\nI'll be posting tutorials on my YouTube channel soon!\n<https://www.youtube.com/@WhatDreamsCost/>\n\n**Where do I download these models??**\n\nThere is a good list of models and download links here: <https://github.com/wildminder/awesome-ltx2?tab=readme-ov-file>\n\nAlso the latest v1.1 spatial upscaler can be found here: <https://huggingface.co/Lightricks/LTX-2.3/tree/main>\n\nThe tiny vae (taeltx2_3.safetensors) is found here:\n<https://huggingface.co/Kijai/LTX2.3_comfy/blob/main/vae/taeltx2_3.safetensors>\n\n**I'm getting errors when running this workflow!**\n\nDouble check that you have all of the correct models loaded. This is using the newest version of 2x upscaler (v1.1). You can change it to the older one under the Model Loader.\n\n**How can I support you??**\n\nHelp me get a job. I'm unemployed and literally broke. (seriously, i'll even scrub toilets for minimum wage)\n\nOr follow me on my socials :)\n\n<https://x.com/WhatDreamsCost>\n\n<https://www.youtube.com/@WhatDreamsCost/>\n\n<https://www.instagram.com/whatdreamscost/>"
+      ],
+      "color": "#322",
+      "bgcolor": "#533"
+    },
+    {
+      "id": 30,
+      "type": "SaveVideo",
+      "pos": [
+        3230,
+        3970
+      ],
+      "size": [
+        690,
+        1133
+      ],
+      "flags": {},
+      "order": 10,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "video",
+          "type": "VIDEO",
+          "link": 249
+        }
+      ],
+      "outputs": [],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.19.3",
+        "Node name for S&R": "SaveVideo",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "video/LTX_Director",
+        "auto",
+        "auto"
+      ],
+      "color": "#222",
+      "bgcolor": "#000"
+    },
+    {
+      "id": 94,
+      "type": "4b017e47-bf16-441b-ad03-edce978b3be3",
+      "pos": [
+        3000,
+        3970
+      ],
+      "size": [
+        210,
+        477.27859237536654
+      ],
+      "flags": {},
+      "order": 7,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "model",
+          "type": "MODEL",
+          "link": 220
+        },
+        {
+          "name": "audio_latent",
+          "type": "LATENT",
+          "link": 221
+        },
+        {
+          "name": "vae",
+          "type": "VAE",
+          "link": 222
+        },
+        {
+          "label": "video_latent",
+          "name": "latent",
+          "type": "LATENT",
+          "link": 223
+        },
+        {
+          "name": "guide_data",
+          "type": "GUIDE_DATA",
+          "link": 224
+        },
+        {
+          "name": "positive",
+          "type": "CONDITIONING",
+          "link": 225
+        },
+        {
+          "name": "frame_rate",
+          "type": "FLOAT",
+          "widget": {
+            "name": "frame_rate"
+          },
+          "link": 226
+        },
+        {
+          "name": "noise_seed",
+          "type": "INT",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "positive",
+          "type": "CONDITIONING",
+          "links": [
+            234
+          ]
+        },
+        {
+          "name": "negative",
+          "type": "CONDITIONING",
+          "links": [
+            235
+          ]
+        },
+        {
+          "name": "NOISE",
+          "type": "NOISE",
+          "links": [
+            240
+          ]
+        },
+        {
+          "name": "video_latent",
+          "type": "LATENT",
+          "links": [
+            236
+          ]
+        },
+        {
+          "name": "audio_latent",
+          "type": "LATENT",
+          "links": [
+            241
+          ]
+        }
+      ],
+      "properties": {
+        "proxyWidgets": [
+          [
+            "5",
+            "frame_rate"
+          ]
+        ],
+        "cnr_id": "comfy-core",
+        "ver": "0.19.3",
+        "ue_properties": {
+          "widget_ue_connectable": {
+            "frame_rate": true
+          },
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [],
+      "color": "#222",
+      "bgcolor": "#000"
+    },
+    {
+      "id": 95,
+      "type": "7cf6430b-4784-4af1-8cde-9268e9465c62",
+      "pos": [
+        3000,
+        4290
+      ],
+      "size": [
+        210,
+        473.27859237536654
+      ],
+      "flags": {},
+      "order": 8,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "positive",
+          "type": "CONDITIONING",
+          "link": 234
+        },
+        {
+          "name": "negative",
+          "type": "CONDITIONING",
+          "link": 235
+        },
+        {
+          "label": "video_latent",
+          "name": "latent",
+          "type": "LATENT",
+          "link": 236
+        },
+        {
+          "label": "video_vae",
+          "name": "vae",
+          "type": "VAE",
+          "link": 237
+        },
+        {
+          "name": "guide_data",
+          "type": "GUIDE_DATA",
+          "link": 238
+        },
+        {
+          "name": "model",
+          "type": "MODEL",
+          "link": 239
+        },
+        {
+          "name": "noise",
+          "type": "NOISE",
+          "link": 240
+        },
+        {
+          "name": "audio_latent",
+          "type": "LATENT",
+          "link": 241
+        }
+      ],
+      "outputs": [
+        {
+          "name": "audio_latent",
+          "type": "LATENT",
+          "links": [
+            244
+          ]
+        },
+        {
+          "name": "latent",
+          "type": "LATENT",
+          "links": [
+            246
+          ]
+        }
+      ],
+      "properties": {
+        "proxyWidgets": [],
+        "cnr_id": "comfy-core",
+        "ver": "0.19.3",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [],
+      "color": "#222",
+      "bgcolor": "#000"
+    },
+    {
+      "id": 46,
+      "type": "LTXDirector",
+      "pos": [
+        1877.2979797979797,
+        3970
+      ],
+      "size": [
+        1120,
+        801
+      ],
+      "flags": {},
+      "order": 6,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "model",
+          "type": "MODEL",
+          "link": 212
+        },
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": 213
+        },
+        {
+          "name": "audio_vae",
+          "shape": 7,
+          "type": "VAE",
+          "link": 215
+        },
+        {
+          "name": "optional_latent",
+          "shape": 7,
+          "type": "LATENT",
+          "link": null
+        },
+        {
+          "name": "local_prompts",
+          "type": "STRING",
+          "widget": {
+            "name": "local_prompts"
+          },
+          "link": 261
+        }
+      ],
+      "outputs": [
+        {
+          "name": "model",
+          "type": "MODEL",
+          "links": [
+            220,
+            239
+          ]
+        },
+        {
+          "name": "positive",
+          "type": "CONDITIONING",
+          "links": [
+            225
+          ]
+        },
+        {
+          "name": "video_latent",
+          "type": "LATENT",
+          "links": [
+            223
+          ]
+        },
+        {
+          "name": "audio_latent",
+          "type": "LATENT",
+          "links": [
+            221
+          ]
+        },
+        {
+          "name": "guide_data",
+          "type": "GUIDE_DATA",
+          "links": [
+            224,
+            238
+          ]
+        },
+        {
+          "name": "frame_rate",
+          "type": "FLOAT",
+          "links": [
+            226,
+            248
+          ]
+        },
+        {
+          "name": "combined_audio",
+          "type": "AUDIO",
+          "links": []
+        }
+      ],
+      "properties": {
+        "aux_id": "kijai/ComfyUI-PromptRelay",
+        "ver": "5cae3c00186ff2eb79771070f05a2c4e02f329bb",
+        "Node name for S&R": "LTXDirector",
+        "cnr_id": "whatdreamscost-comfyui",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "",
+        240,
+        10,
+        "{\"segments\":[{\"id\":\"seg1\",\"start\":0,\"length\":120,\"prompt\":\"\",\"type\":\"image\",\"imageFile\":\"\",\"imageB64\":\"\"},{\"id\":\"seg2\",\"start\":120,\"length\":120,\"prompt\":\"\",\"type\":\"text\"}],\"audioSegments\":[]}",
+        "",
+        "120,120",
+        0.001,
+        "1.00,1.00",
+        false,
+        24,
+        "seconds",
+        0,
+        0,
+        "maintain aspect ratio",
+        32,
+        18,
+        ""
+      ]
+    },
+    {
+      "id": 93,
+      "type": "dc399e64-01cd-40b2-9337-972428cc66de",
+      "pos": [
+        1263.0744949494963,
+        4009.785353535356
+      ],
+      "size": [
+        400,
+        190
+      ],
+      "flags": {},
+      "order": 5,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "label": "model",
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": [
+            212
+          ]
+        },
+        {
+          "label": "clip",
+          "name": "CLIP",
+          "type": "CLIP",
+          "links": [
+            213
+          ]
+        },
+        {
+          "label": "audio_vae",
+          "name": "VAE",
+          "type": "VAE",
+          "links": [
+            215,
+            245
+          ]
+        },
+        {
+          "label": "video_vae",
+          "name": "VAE_1",
+          "type": "VAE",
+          "links": [
+            222,
+            237,
+            247
+          ]
+        }
+      ],
+      "properties": {
+        "proxyWidgets": [
+          [
+            "77",
+            "ckpt_name"
+          ],
+          [
+            "84",
+            "clip_name1"
+          ],
+          [
+            "4",
+            "vae_name"
+          ],
+          [
+            "3",
+            "vae_name"
+          ]
+        ],
+        "cnr_id": "comfy-core",
+        "ver": "0.19.3",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [],
+      "color": "#222",
+      "bgcolor": "#000"
+    }
+  ],
+  "links": [
+    [
+      259,
+      105,
+      0,
+      106,
+      0,
+      "IMAGE"
+    ],
+    [
+      260,
+      106,
+      0,
+      107,
+      1,
+      "STRING"
+    ],
+    [
+      261,
+      107,
+      0,
+      46,
+      4,
+      "STRING"
+    ],
+    [
+      212,
+      93,
+      0,
+      46,
+      0,
+      "MODEL"
+    ],
+    [
+      213,
+      93,
+      1,
+      46,
+      1,
+      "CLIP"
+    ],
+    [
+      215,
+      93,
+      2,
+      46,
+      2,
+      "VAE"
+    ],
+    [
+      220,
+      46,
+      0,
+      94,
+      0,
+      "MODEL"
+    ],
+    [
+      221,
+      46,
+      3,
+      94,
+      1,
+      "LATENT"
+    ],
+    [
+      222,
+      93,
+      3,
+      94,
+      2,
+      "VAE"
+    ],
+    [
+      223,
+      46,
+      2,
+      94,
+      3,
+      "LATENT"
+    ],
+    [
+      224,
+      46,
+      4,
+      94,
+      4,
+      "GUIDE_DATA"
+    ],
+    [
+      225,
+      46,
+      1,
+      94,
+      5,
+      "CONDITIONING"
+    ],
+    [
+      226,
+      46,
+      5,
+      94,
+      6,
+      "FLOAT"
+    ],
+    [
+      234,
+      94,
+      0,
+      95,
+      0,
+      "CONDITIONING"
+    ],
+    [
+      235,
+      94,
+      1,
+      95,
+      1,
+      "CONDITIONING"
+    ],
+    [
+      236,
+      94,
+      3,
+      95,
+      2,
+      "LATENT"
+    ],
+    [
+      237,
+      93,
+      3,
+      95,
+      3,
+      "VAE"
+    ],
+    [
+      238,
+      46,
+      4,
+      95,
+      4,
+      "GUIDE_DATA"
+    ],
+    [
+      239,
+      46,
+      0,
+      95,
+      5,
+      "MODEL"
+    ],
+    [
+      240,
+      94,
+      2,
+      95,
+      6,
+      "NOISE"
+    ],
+    [
+      241,
+      94,
+      4,
+      95,
+      7,
+      "LATENT"
+    ],
+    [
+      244,
+      95,
+      0,
+      96,
+      0,
+      "LATENT"
+    ],
+    [
+      245,
+      93,
+      2,
+      96,
+      1,
+      "VAE"
+    ],
+    [
+      246,
+      95,
+      1,
+      96,
+      2,
+      "LATENT"
+    ],
+    [
+      247,
+      93,
+      3,
+      96,
+      3,
+      "VAE"
+    ],
+    [
+      248,
+      46,
+      5,
+      96,
+      4,
+      "FLOAT"
+    ],
+    [
+      249,
+      96,
+      0,
+      30,
+      0,
+      "VIDEO"
+    ]
+  ],
+  "groups": [],
+  "definitions": {
+    "subgraphs": [
+      {
+        "id": "dc399e64-01cd-40b2-9337-972428cc66de",
+        "version": 1,
+        "state": {
+          "lastGroupId": 6,
+          "lastNodeId": 104,
+          "lastLinkId": 258,
+          "lastRerouteId": 0
+        },
+        "revision": 0,
+        "config": {},
+        "name": "Model Loader",
+        "inputNode": {
+          "id": -10,
+          "bounding": [
+            1060,
+            4265,
+            128,
+            48
+          ]
+        },
+        "outputNode": {
+          "id": -20,
+          "bounding": [
+            1870,
+            4225,
+            128,
+            128
+          ]
+        },
+        "inputs": [],
+        "outputs": [
+          {
+            "id": "68f91346-0127-4451-a92f-5cfb56fc7f02",
+            "name": "MODEL",
+            "type": "MODEL",
+            "linkIds": [
+              199
+            ],
+            "localized_name": "MODEL",
+            "label": "model",
+            "pos": [
+              1894,
+              4249
+            ]
+          },
+          {
+            "id": "d50bc485-29c2-44a9-9653-fbb738989bdc",
+            "name": "CLIP",
+            "type": "CLIP",
+            "linkIds": [
+              254
+            ],
+            "localized_name": "CLIP",
+            "label": "clip",
+            "pos": [
+              1894,
+              4269
+            ]
+          },
+          {
+            "id": "cfbbcf84-8477-40b1-a7ba-318c8d3b03a0",
+            "name": "VAE",
+            "type": "VAE",
+            "linkIds": [
+              58,
+              58
+            ],
+            "localized_name": "VAE",
+            "label": "audio_vae",
+            "pos": [
+              1894,
+              4289
+            ]
+          },
+          {
+            "id": "815c9c85-34bc-49fc-8161-aca22b170346",
+            "name": "VAE_1",
+            "type": "VAE",
+            "linkIds": [
+              16,
+              16,
+              16,
+              16
+            ],
+            "localized_name": "VAE_1",
+            "label": "video_vae",
+            "pos": [
+              1894,
+              4309
+            ]
+          }
+        ],
+        "widgets": [],
+        "nodes": [
+          {
+            "id": 78,
+            "type": "VAELoaderKJ",
+            "pos": [
+              1530,
+              3870
+            ],
+            "size": [
+              270,
+              110
+            ],
+            "flags": {},
+            "order": 0,
+            "mode": 0,
+            "inputs": [],
+            "outputs": [
+              {
+                "localized_name": "VAE",
+                "name": "VAE",
+                "type": "VAE",
+                "links": [
+                  196
+                ]
+              }
+            ],
+            "title": "Tiny VAELoader KJ",
+            "properties": {
+              "cnr_id": "comfyui-kjnodes",
+              "ver": "1.2.5",
+              "Node name for S&R": "VAELoaderKJ",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              }
+            },
+            "widgets_values": [
+              "taeltx2_3.safetensors",
+              "main_device",
+              "bf16"
+            ],
+            "color": "#222",
+            "bgcolor": "#000"
+          },
+          {
+            "id": 4,
+            "type": "VAELoaderKJ",
+            "pos": [
+              1530,
+              4470
+            ],
+            "size": [
+              260,
+              110
+            ],
+            "flags": {},
+            "order": 1,
+            "mode": 0,
+            "inputs": [
+              {
+                "label": "audio_vae",
+                "localized_name": "vae_name",
+                "name": "vae_name",
+                "type": "COMBO",
+                "widget": {
+                  "name": "vae_name"
+                },
+                "link": null
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "VAE",
+                "name": "VAE",
+                "type": "VAE",
+                "links": [
+                  58
+                ]
+              }
+            ],
+            "title": "Audio VAELoader",
+            "properties": {
+              "cnr_id": "comfyui-kjnodes",
+              "ver": "487c7d86a0230aae3d8c0a37d517159b73834f85",
+              "Node name for S&R": "VAELoaderKJ",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              }
+            },
+            "widgets_values": [
+              "LTX23_audio_vae_bf16.safetensors",
+              "main_device",
+              "bf16"
+            ],
+            "color": "#222",
+            "bgcolor": "#000"
+          },
+          {
+            "id": 3,
+            "type": "VAELoaderKJ",
+            "pos": [
+              1530,
+              4620
+            ],
+            "size": [
+              260,
+              110
+            ],
+            "flags": {},
+            "order": 2,
+            "mode": 0,
+            "inputs": [
+              {
+                "label": "video_vae",
+                "localized_name": "vae_name",
+                "name": "vae_name",
+                "type": "COMBO",
+                "widget": {
+                  "name": "vae_name"
+                },
+                "link": null
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "VAE",
+                "name": "VAE",
+                "type": "VAE",
+                "links": [
+                  16
+                ]
+              }
+            ],
+            "title": "Video VAELoader",
+            "properties": {
+              "cnr_id": "comfyui-kjnodes",
+              "ver": "1.2.5",
+              "Node name for S&R": "VAELoaderKJ",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              }
+            },
+            "widgets_values": [
+              "LTX23_video_vae_bf16.safetensors",
+              "main_device",
+              "bf16"
+            ],
+            "color": "#222",
+            "bgcolor": "#000"
+          },
+          {
+            "id": 84,
+            "type": "DualCLIPLoader",
+            "pos": [
+              1530,
+              4290
+            ],
+            "size": [
+              270,
+              130
+            ],
+            "flags": {},
+            "order": 3,
+            "mode": 0,
+            "inputs": [
+              {
+                "label": "text_encoder",
+                "localized_name": "clip_name1",
+                "name": "clip_name1",
+                "type": "COMBO",
+                "widget": {
+                  "name": "clip_name1"
+                },
+                "link": null
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "CLIP",
+                "name": "CLIP",
+                "type": "CLIP",
+                "links": [
+                  253
+                ]
+              }
+            ],
+            "properties": {
+              "cnr_id": "comfy-core",
+              "ver": "0.19.3",
+              "Node name for S&R": "DualCLIPLoader",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              }
+            },
+            "widgets_values": [
+              "gemma_3_12B_it_heretic_fp8_e4m3fn.safetensors",
+              "ltx-2.3_text_projection_bf16.safetensors",
+              "ltxv",
+              "default"
+            ],
+            "color": "#222",
+            "bgcolor": "#000"
+          },
+          {
+            "id": 101,
+            "type": "Power Lora Loader (rgthree)",
+            "pos": [
+              183.20476390844237,
+              2852.236802764441
+            ],
+            "size": [
+              340.519921875,
+              622
+            ],
+            "flags": {},
+            "order": 4,
+            "mode": 0,
+            "inputs": [
+              {
+                "dir": 3,
+                "name": "model",
+                "type": "MODEL",
+                "link": null
+              },
+              {
+                "dir": 3,
+                "name": "clip",
+                "type": "CLIP",
+                "link": null
+              }
+            ],
+            "outputs": [
+              {
+                "dir": 4,
+                "name": "MODEL",
+                "shape": 3,
+                "type": "MODEL",
+                "links": null
+              },
+              {
+                "dir": 4,
+                "name": "CLIP",
+                "shape": 3,
+                "type": "CLIP",
+                "links": null
+              }
+            ],
+            "properties": {
+              "cnr_id": "rgthree-comfy",
+              "ver": "738105af5fb14e96fbecaf406dc356e284797e8c",
+              "Show Strengths": "Single Strength",
+              "Match": "",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "input_ue_unconnectable": {},
+                "version": "7.8"
+              }
+            },
+            "widgets_values": [
+              {},
+              {
+                "type": "PowerLoraLoaderHeaderWidget"
+              },
+              {
+                "on": true,
+                "lora": "LTX2\\LTX2.3_reasoning_I2V_V3.safetensors",
+                "strength": 0.5,
+                "strengthTwo": null
+              },
+              {
+                "on": true,
+                "lora": "LTX2\\DR34ML4Y_LTXXX_PREVIEW_RC1.safetensors",
+                "strength": 0.5,
+                "strengthTwo": null
+              },
+              {},
+              ""
+            ]
+          },
+          {
+            "id": 77,
+            "type": "CheckpointLoaderSimple",
+            "pos": [
+              1175.9530791788861,
+              4016.4418377321604
+            ],
+            "size": [
+              270,
+              100
+            ],
+            "flags": {},
+            "order": 5,
+            "mode": 0,
+            "inputs": [
+              {
+                "label": "model",
+                "localized_name": "ckpt_name",
+                "name": "ckpt_name",
+                "type": "COMBO",
+                "widget": {
+                  "name": "ckpt_name"
+                },
+                "link": null
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "MODEL",
+                "name": "MODEL",
+                "type": "MODEL",
+                "links": [
+                  255
+                ]
+              },
+              {
+                "localized_name": "CLIP",
+                "name": "CLIP",
+                "type": "CLIP",
+                "links": null
+              },
+              {
+                "localized_name": "VAE",
+                "name": "VAE",
+                "type": "VAE",
+                "links": null
+              }
+            ],
+            "properties": {
+              "cnr_id": "comfy-core",
+              "ver": "0.17.2",
+              "Node name for S&R": "CheckpointLoaderSimple",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              }
+            },
+            "widgets_values": [
+              "ltx2310eros_beta.safetensors"
+            ],
+            "color": "#222",
+            "bgcolor": "#000"
+          },
+          {
+            "id": 79,
+            "type": "LTX2SamplingPreviewOverride",
+            "pos": [
+              1530,
+              4020
+            ],
+            "size": [
+              270,
+              100
+            ],
+            "flags": {},
+            "order": 6,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "model",
+                "name": "model",
+                "type": "MODEL",
+                "link": 255
+              },
+              {
+                "localized_name": "latent_upscale_model",
+                "name": "latent_upscale_model",
+                "shape": 7,
+                "type": "LATENT_UPSCALE_MODEL",
+                "link": null
+              },
+              {
+                "localized_name": "vae",
+                "name": "vae",
+                "shape": 7,
+                "type": "VAE",
+                "link": 196
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "MODEL",
+                "name": "MODEL",
+                "type": "MODEL",
+                "links": [
+                  256
+                ]
+              }
+            ],
+            "properties": {
+              "cnr_id": "comfyui-kjnodes",
+              "ver": "1.3.4",
+              "Node name for S&R": "LTX2SamplingPreviewOverride",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              }
+            },
+            "widgets_values": [
+              24
+            ],
+            "color": "#222",
+            "bgcolor": "#000"
+          },
+          {
+            "id": 102,
+            "type": "Power Lora Loader (rgthree)",
+            "pos": [
+              2255.0773323012236,
+              4190.796594765089
+            ],
+            "size": [
+              340.519921875,
+              622
+            ],
+            "flags": {},
+            "order": 7,
+            "mode": 0,
+            "inputs": [
+              {
+                "dir": 3,
+                "name": "model",
+                "type": "MODEL",
+                "link": 256
+              },
+              {
+                "dir": 3,
+                "name": "clip",
+                "type": "CLIP",
+                "link": 253
+              }
+            ],
+            "outputs": [
+              {
+                "dir": 4,
+                "name": "MODEL",
+                "shape": 3,
+                "type": "MODEL",
+                "links": [
+                  257
+                ]
+              },
+              {
+                "dir": 4,
+                "name": "CLIP",
+                "shape": 3,
+                "type": "CLIP",
+                "links": [
+                  254
+                ]
+              }
+            ],
+            "properties": {
+              "cnr_id": "rgthree-comfy",
+              "ver": "738105af5fb14e96fbecaf406dc356e284797e8c",
+              "Show Strengths": "Single Strength",
+              "Match": "",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "input_ue_unconnectable": {},
+                "version": "7.8"
+              }
+            },
+            "widgets_values": [
+              {},
+              {
+                "type": "PowerLoraLoaderHeaderWidget"
+              },
+              {
+                "on": true,
+                "lora": "LTX2\\LTX2.3_reasoning_I2V_V3.safetensors",
+                "strength": 0.5,
+                "strengthTwo": null
+              },
+              {
+                "on": true,
+                "lora": "LTX2\\DR34ML4Y_LTXXX_PREVIEW_RC1.safetensors",
+                "strength": 0.5,
+                "strengthTwo": null
+              },
+              {},
+              ""
+            ]
+          },
+          {
+            "id": 80,
+            "type": "LoraLoaderModelOnly",
+            "pos": [
+              1215.5255907687376,
+              4164.482882371204
+            ],
+            "size": [
+              471.99154371923714,
+              101.34127262476522
+            ],
+            "flags": {},
+            "order": 8,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "model",
+                "name": "model",
+                "type": "MODEL",
+                "link": 257
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "MODEL",
+                "name": "MODEL",
+                "type": "MODEL",
+                "links": [
+                  199
+                ]
+              }
+            ],
+            "properties": {
+              "cnr_id": "comfy-core",
+              "ver": "0.3.75",
+              "Node name for S&R": "LoraLoaderModelOnly",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              }
+            },
+            "widgets_values": [
+              "ltx-2.3-22b-distilled-lora-dynamic_fro09_avg_rank_105_bf16.safetensors",
+              0.5
+            ],
+            "color": "#222",
+            "bgcolor": "#000"
+          }
+        ],
+        "groups": [],
+        "links": [
+          {
+            "id": 196,
+            "origin_id": 78,
+            "origin_slot": 0,
+            "target_id": 79,
+            "target_slot": 2,
+            "type": "VAE"
+          },
+          {
+            "id": 199,
+            "origin_id": 80,
+            "origin_slot": 0,
+            "target_id": -20,
+            "target_slot": 0,
+            "type": "MODEL"
+          },
+          {
+            "id": 58,
+            "origin_id": 4,
+            "origin_slot": 0,
+            "target_id": -20,
+            "target_slot": 2,
+            "type": "VAE"
+          },
+          {
+            "id": 16,
+            "origin_id": 3,
+            "origin_slot": 0,
+            "target_id": -20,
+            "target_slot": 3,
+            "type": "VAE"
+          },
+          {
+            "id": 253,
+            "origin_id": 84,
+            "origin_slot": 0,
+            "target_id": 102,
+            "target_slot": 1,
+            "type": "CLIP"
+          },
+          {
+            "id": 254,
+            "origin_id": 102,
+            "origin_slot": 1,
+            "target_id": -20,
+            "target_slot": 1,
+            "type": "CLIP"
+          },
+          {
+            "id": 255,
+            "origin_id": 77,
+            "origin_slot": 0,
+            "target_id": 79,
+            "target_slot": 0,
+            "type": "MODEL"
+          },
+          {
+            "id": 256,
+            "origin_id": 79,
+            "origin_slot": 0,
+            "target_id": 102,
+            "target_slot": 0,
+            "type": "MODEL"
+          },
+          {
+            "id": 257,
+            "origin_id": 102,
+            "origin_slot": 0,
+            "target_id": 80,
+            "target_slot": 0,
+            "type": "MODEL"
+          }
+        ],
+        "extra": {
+          "workflowRendererVersion": "LG",
+          "ue_links": [],
+          "links_added_by_ue": []
+        }
+      },
+      {
+        "id": "4b017e47-bf16-441b-ad03-edce978b3be3",
+        "version": 1,
+        "state": {
+          "lastGroupId": 6,
+          "lastNodeId": 104,
+          "lastLinkId": 258,
+          "lastRerouteId": 0
+        },
+        "revision": 0,
+        "config": {},
+        "name": "Stage #1",
+        "inputNode": {
+          "id": -10,
+          "bounding": [
+            2860,
+            4380,
+            128,
+            208
+          ]
+        },
+        "outputNode": {
+          "id": -20,
+          "bounding": [
+            4450,
+            4360,
+            128,
+            148
+          ]
+        },
+        "inputs": [
+          {
+            "id": "3c716dfb-4465-4519-8705-d5e7b88f1e35",
+            "name": "model",
+            "type": "MODEL",
+            "linkIds": [
+              115,
+              114
+            ],
+            "localized_name": "model",
+            "pos": [
+              2964,
+              4404
+            ]
+          },
+          {
+            "id": "dcb44156-9e87-4ef1-a7fd-6b8cb4de0beb",
+            "name": "audio_latent",
+            "type": "LATENT",
+            "linkIds": [
+              119
+            ],
+            "localized_name": "audio_latent",
+            "pos": [
+              2964,
+              4424
+            ]
+          },
+          {
+            "id": "0c7b8f30-c29e-4147-96e9-db7f6ca77e06",
+            "name": "vae",
+            "type": "VAE",
+            "linkIds": [
+              216
+            ],
+            "localized_name": "vae",
+            "pos": [
+              2964,
+              4444
+            ]
+          },
+          {
+            "id": "4286d415-0cbb-4310-94d2-0efdccfb429f",
+            "name": "latent",
+            "type": "LATENT",
+            "linkIds": [
+              118
+            ],
+            "localized_name": "latent",
+            "label": "video_latent",
+            "pos": [
+              2964,
+              4464
+            ]
+          },
+          {
+            "id": "24eebedb-6830-4afb-9337-bd06b1300d44",
+            "name": "guide_data",
+            "type": "GUIDE_DATA",
+            "linkIds": [
+              122
+            ],
+            "localized_name": "guide_data",
+            "pos": [
+              2964,
+              4484
+            ]
+          },
+          {
+            "id": "1dc63a0e-c430-406b-86a8-6eb45cbc7885",
+            "name": "positive",
+            "type": "CONDITIONING",
+            "linkIds": [
+              116,
+              117
+            ],
+            "localized_name": "positive",
+            "pos": [
+              2964,
+              4504
+            ]
+          },
+          {
+            "id": "02c2f048-017d-4fec-8440-19aa412bf8c0",
+            "name": "frame_rate",
+            "type": "FLOAT",
+            "linkIds": [
+              120
+            ],
+            "localized_name": "frame_rate",
+            "pos": [
+              2964,
+              4524
+            ]
+          },
+          {
+            "id": "f8636f26-27cb-4c55-972e-e5d1f6f39fff",
+            "name": "noise_seed",
+            "type": "INT",
+            "linkIds": [],
+            "pos": [
+              2964,
+              4544
+            ]
+          }
+        ],
+        "outputs": [
+          {
+            "id": "84f8d65a-1c3c-4fdc-8cab-7abaf67c1875",
+            "name": "positive",
+            "type": "CONDITIONING",
+            "linkIds": [
+              54,
+              54
+            ],
+            "localized_name": "positive",
+            "pos": [
+              4474,
+              4384
+            ]
+          },
+          {
+            "id": "6275837a-94b0-4318-bbce-15969c26e42b",
+            "name": "negative",
+            "type": "CONDITIONING",
+            "linkIds": [
+              55,
+              55
+            ],
+            "localized_name": "negative",
+            "pos": [
+              4474,
+              4404
+            ]
+          },
+          {
+            "id": "4c1b1c7e-3c92-4c13-8495-539df653574e",
+            "name": "NOISE",
+            "type": "NOISE",
+            "linkIds": [
+              157
+            ],
+            "localized_name": "NOISE",
+            "pos": [
+              4474,
+              4424
+            ]
+          },
+          {
+            "id": "f0f1c347-9ebf-496e-aea8-ca0a0ff7601e",
+            "name": "video_latent",
+            "type": "LATENT",
+            "linkIds": [
+              142
+            ],
+            "localized_name": "video_latent",
+            "pos": [
+              4474,
+              4444
+            ]
+          },
+          {
+            "id": "bf7e617a-cf3a-4ef6-a485-d3ab3e84742a",
+            "name": "audio_latent",
+            "type": "LATENT",
+            "linkIds": [
+              143
+            ],
+            "localized_name": "audio_latent",
+            "pos": [
+              4474,
+              4464
+            ]
+          }
+        ],
+        "widgets": [],
+        "nodes": [
+          {
+            "id": 11,
+            "type": "BasicScheduler",
+            "pos": [
+              3740,
+              4620
+            ],
+            "size": [
+              210,
+              110
+            ],
+            "flags": {},
+            "order": 7,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "model",
+                "name": "model",
+                "type": "MODEL",
+                "link": 115
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "SIGMAS",
+                "name": "SIGMAS",
+                "type": "SIGMAS",
+                "links": [
+                  52
+                ]
+              }
+            ],
+            "properties": {
+              "cnr_id": "comfy-core",
+              "ver": "0.16.4",
+              "Node name for S&R": "BasicScheduler",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              }
+            },
+            "widgets_values": [
+              "linear_quadratic",
+              8,
+              1
+            ],
+            "color": "#222",
+            "bgcolor": "#000"
+          },
+          {
+            "id": 10,
+            "type": "SamplerCustomAdvanced",
+            "pos": [
+              3960,
+              4390
+            ],
+            "size": [
+              220,
+              428.2932551319648
+            ],
+            "flags": {},
+            "order": 6,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "noise",
+                "name": "noise",
+                "type": "NOISE",
+                "link": 51
+              },
+              {
+                "localized_name": "guider",
+                "name": "guider",
+                "type": "GUIDER",
+                "link": 12
+              },
+              {
+                "localized_name": "sampler",
+                "name": "sampler",
+                "type": "SAMPLER",
+                "link": 53
+              },
+              {
+                "localized_name": "sigmas",
+                "name": "sigmas",
+                "type": "SIGMAS",
+                "link": 52
+              },
+              {
+                "localized_name": "latent_image",
+                "name": "latent_image",
+                "type": "LATENT",
+                "link": 14
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "output",
+                "name": "output",
+                "type": "LATENT",
+                "links": [
+                  156
+                ]
+              },
+              {
+                "localized_name": "denoised_output",
+                "name": "denoised_output",
+                "type": "LATENT",
+                "links": []
+              }
+            ],
+            "properties": {
+              "cnr_id": "comfy-core",
+              "ver": "0.3.60",
+              "Node name for S&R": "SamplerCustomAdvanced",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              }
+            },
+            "widgets_values": [],
+            "color": "#222",
+            "bgcolor": "#000"
+          },
+          {
+            "id": 29,
+            "type": "KSamplerSelect",
+            "pos": [
+              3740,
+              4520
+            ],
+            "size": [
+              210,
+              60
+            ],
+            "flags": {},
+            "order": 0,
+            "mode": 0,
+            "inputs": [],
+            "outputs": [
+              {
+                "localized_name": "SAMPLER",
+                "name": "SAMPLER",
+                "type": "SAMPLER",
+                "links": [
+                  53
+                ]
+              }
+            ],
+            "properties": {
+              "cnr_id": "comfy-core",
+              "ver": "0.3.56",
+              "Node name for S&R": "KSamplerSelect",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              }
+            },
+            "widgets_values": [
+              "euler"
+            ],
+            "color": "#222",
+            "bgcolor": "#000"
+          },
+          {
+            "id": 7,
+            "type": "LTXVConcatAVLatent",
+            "pos": [
+              3520,
+              4530
+            ],
+            "size": [
+              210,
+              50
+            ],
+            "flags": {},
+            "order": 3,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "video_latent",
+                "name": "video_latent",
+                "type": "LATENT",
+                "link": 108
+              },
+              {
+                "localized_name": "audio_latent",
+                "name": "audio_latent",
+                "type": "LATENT",
+                "link": 119
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "latent",
+                "name": "latent",
+                "type": "LATENT",
+                "links": [
+                  14
+                ]
+              }
+            ],
+            "properties": {
+              "cnr_id": "comfy-core",
+              "ver": "0.16.0",
+              "Node name for S&R": "LTXVConcatAVLatent",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              }
+            },
+            "widgets_values": [],
+            "color": "#222",
+            "bgcolor": "#000"
+          },
+          {
+            "id": 8,
+            "type": "LTXDirectorGuide",
+            "pos": [
+              3290,
+              4400
+            ],
+            "size": [
+              210,
+              180
+            ],
+            "flags": {},
+            "order": 4,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "positive",
+                "name": "positive",
+                "type": "CONDITIONING",
+                "link": 6
+              },
+              {
+                "localized_name": "negative",
+                "name": "negative",
+                "type": "CONDITIONING",
+                "link": 7
+              },
+              {
+                "localized_name": "vae",
+                "name": "vae",
+                "type": "VAE",
+                "link": 216
+              },
+              {
+                "localized_name": "latent",
+                "name": "latent",
+                "type": "LATENT",
+                "link": 118
+              },
+              {
+                "localized_name": "guide_data",
+                "name": "guide_data",
+                "type": "GUIDE_DATA",
+                "link": 122
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "positive",
+                "name": "positive",
+                "type": "CONDITIONING",
+                "links": [
+                  10,
+                  54
+                ]
+              },
+              {
+                "localized_name": "negative",
+                "name": "negative",
+                "type": "CONDITIONING",
+                "links": [
+                  11,
+                  55
+                ]
+              },
+              {
+                "localized_name": "latent",
+                "name": "latent",
+                "type": "LATENT",
+                "links": [
+                  108
+                ]
+              }
+            ],
+            "properties": {
+              "aux_id": "kijai/ComfyUI-PromptRelay",
+              "ver": "5cae3c00186ff2eb79771070f05a2c4e02f329bb",
+              "Node name for S&R": "LTXDirectorGuide",
+              "cnr_id": "whatdreamscost-comfyui",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              }
+            },
+            "widgets_values": [
+              0.5,
+              "bicubic"
+            ],
+            "color": "#222",
+            "bgcolor": "#000"
+          },
+          {
+            "id": 9,
+            "type": "CFGGuider",
+            "pos": [
+              3520,
+              4390
+            ],
+            "size": [
+              210,
+              100
+            ],
+            "flags": {},
+            "order": 5,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "model",
+                "name": "model",
+                "type": "MODEL",
+                "link": 114
+              },
+              {
+                "localized_name": "positive",
+                "name": "positive",
+                "type": "CONDITIONING",
+                "link": 10
+              },
+              {
+                "localized_name": "negative",
+                "name": "negative",
+                "type": "CONDITIONING",
+                "link": 11
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "GUIDER",
+                "name": "GUIDER",
+                "type": "GUIDER",
+                "links": [
+                  12
+                ]
+              }
+            ],
+            "properties": {
+              "cnr_id": "comfy-core",
+              "ver": "0.3.64",
+              "Node name for S&R": "CFGGuider",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              }
+            },
+            "widgets_values": [
+              1
+            ],
+            "color": "#222",
+            "bgcolor": "#000"
+          },
+          {
+            "id": 5,
+            "type": "LTXVConditioning",
+            "pos": [
+              3040,
+              4400
+            ],
+            "size": [
+              240,
+              80
+            ],
+            "flags": {},
+            "order": 2,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "positive",
+                "name": "positive",
+                "type": "CONDITIONING",
+                "link": 116
+              },
+              {
+                "localized_name": "negative",
+                "name": "negative",
+                "type": "CONDITIONING",
+                "link": 50
+              },
+              {
+                "localized_name": "frame_rate",
+                "name": "frame_rate",
+                "type": "FLOAT",
+                "widget": {
+                  "name": "frame_rate"
+                },
+                "link": 120
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "positive",
+                "name": "positive",
+                "type": "CONDITIONING",
+                "links": [
+                  6
+                ]
+              },
+              {
+                "localized_name": "negative",
+                "name": "negative",
+                "type": "CONDITIONING",
+                "links": [
+                  7
+                ]
+              }
+            ],
+            "properties": {
+              "cnr_id": "comfy-core",
+              "ver": "0.3.56",
+              "Node name for S&R": "LTXVConditioning",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              }
+            },
+            "widgets_values": [
+              24
+            ],
+            "color": "#222",
+            "bgcolor": "#000"
+          },
+          {
+            "id": 26,
+            "type": "ConditioningZeroOut",
+            "pos": [
+              3040,
+              4530
+            ],
+            "size": [
+              240,
+              30
+            ],
+            "flags": {},
+            "order": 9,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "conditioning",
+                "name": "conditioning",
+                "type": "CONDITIONING",
+                "link": 117
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "CONDITIONING",
+                "name": "CONDITIONING",
+                "type": "CONDITIONING",
+                "links": [
+                  50
+                ]
+              }
+            ],
+            "properties": {
+              "cnr_id": "comfy-core",
+              "ver": "0.19.3",
+              "Node name for S&R": "ConditioningZeroOut",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              }
+            },
+            "widgets_values": [],
+            "color": "#222",
+            "bgcolor": "#000"
+          },
+          {
+            "id": 13,
+            "type": "LTXVSeparateAVLatent",
+            "pos": [
+              4190,
+              4390
+            ],
+            "size": [
+              200,
+              50
+            ],
+            "flags": {},
+            "order": 8,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "av_latent",
+                "name": "av_latent",
+                "type": "LATENT",
+                "link": 156
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "video_latent",
+                "name": "video_latent",
+                "type": "LATENT",
+                "links": [
+                  142
+                ]
+              },
+              {
+                "localized_name": "audio_latent",
+                "name": "audio_latent",
+                "type": "LATENT",
+                "links": [
+                  143
+                ]
+              }
+            ],
+            "properties": {
+              "cnr_id": "comfy-core",
+              "ver": "0.16.0",
+              "Node name for S&R": "LTXVSeparateAVLatent",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              }
+            },
+            "widgets_values": [],
+            "color": "#222",
+            "bgcolor": "#000"
+          },
+          {
+            "id": 28,
+            "type": "RandomNoise",
+            "pos": [
+              3431.7423547807693,
+              4693.424337193137
+            ],
+            "size": [
+              210,
+              90
+            ],
+            "flags": {},
+            "order": 1,
+            "mode": 0,
+            "inputs": [
+              {
+                "label": "noise_seed",
+                "localized_name": "noise_seed",
+                "name": "noise_seed",
+                "type": "INT",
+                "widget": {
+                  "name": "noise_seed"
+                },
+                "link": null
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "NOISE",
+                "name": "NOISE",
+                "type": "NOISE",
+                "links": [
+                  51,
+                  157
+                ]
+              }
+            ],
+            "properties": {
+              "cnr_id": "comfy-core",
+              "ver": "0.19.3",
+              "Node name for S&R": "RandomNoise",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              }
+            },
+            "widgets_values": [
+              243141763309034,
+              "randomize"
+            ],
+            "color": "#222",
+            "bgcolor": "#000"
+          }
+        ],
+        "groups": [],
+        "links": [
+          {
+            "id": 51,
+            "origin_id": 28,
+            "origin_slot": 0,
+            "target_id": 10,
+            "target_slot": 0,
+            "type": "NOISE"
+          },
+          {
+            "id": 12,
+            "origin_id": 9,
+            "origin_slot": 0,
+            "target_id": 10,
+            "target_slot": 1,
+            "type": "GUIDER"
+          },
+          {
+            "id": 53,
+            "origin_id": 29,
+            "origin_slot": 0,
+            "target_id": 10,
+            "target_slot": 2,
+            "type": "SAMPLER"
+          },
+          {
+            "id": 52,
+            "origin_id": 11,
+            "origin_slot": 0,
+            "target_id": 10,
+            "target_slot": 3,
+            "type": "SIGMAS"
+          },
+          {
+            "id": 14,
+            "origin_id": 7,
+            "origin_slot": 0,
+            "target_id": 10,
+            "target_slot": 4,
+            "type": "LATENT"
+          },
+          {
+            "id": 108,
+            "origin_id": 8,
+            "origin_slot": 2,
+            "target_id": 7,
+            "target_slot": 0,
+            "type": "LATENT"
+          },
+          {
+            "id": 6,
+            "origin_id": 5,
+            "origin_slot": 0,
+            "target_id": 8,
+            "target_slot": 0,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 7,
+            "origin_id": 5,
+            "origin_slot": 1,
+            "target_id": 8,
+            "target_slot": 1,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 10,
+            "origin_id": 8,
+            "origin_slot": 0,
+            "target_id": 9,
+            "target_slot": 1,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 11,
+            "origin_id": 8,
+            "origin_slot": 1,
+            "target_id": 9,
+            "target_slot": 2,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 50,
+            "origin_id": 26,
+            "origin_slot": 0,
+            "target_id": 5,
+            "target_slot": 1,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 156,
+            "origin_id": 10,
+            "origin_slot": 0,
+            "target_id": 13,
+            "target_slot": 0,
+            "type": "LATENT"
+          },
+          {
+            "id": 115,
+            "origin_id": -10,
+            "origin_slot": 0,
+            "target_id": 11,
+            "target_slot": 0,
+            "type": "MODEL"
+          },
+          {
+            "id": 114,
+            "origin_id": -10,
+            "origin_slot": 0,
+            "target_id": 9,
+            "target_slot": 0,
+            "type": "MODEL"
+          },
+          {
+            "id": 119,
+            "origin_id": -10,
+            "origin_slot": 1,
+            "target_id": 7,
+            "target_slot": 1,
+            "type": "LATENT"
+          },
+          {
+            "id": 216,
+            "origin_id": -10,
+            "origin_slot": 2,
+            "target_id": 8,
+            "target_slot": 2,
+            "type": "VAE"
+          },
+          {
+            "id": 118,
+            "origin_id": -10,
+            "origin_slot": 3,
+            "target_id": 8,
+            "target_slot": 3,
+            "type": "LATENT"
+          },
+          {
+            "id": 122,
+            "origin_id": -10,
+            "origin_slot": 4,
+            "target_id": 8,
+            "target_slot": 4,
+            "type": "GUIDE_DATA"
+          },
+          {
+            "id": 116,
+            "origin_id": -10,
+            "origin_slot": 5,
+            "target_id": 5,
+            "target_slot": 0,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 117,
+            "origin_id": -10,
+            "origin_slot": 5,
+            "target_id": 26,
+            "target_slot": 0,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 120,
+            "origin_id": -10,
+            "origin_slot": 6,
+            "target_id": 5,
+            "target_slot": 2,
+            "type": "FLOAT"
+          },
+          {
+            "id": 54,
+            "origin_id": 8,
+            "origin_slot": 0,
+            "target_id": -20,
+            "target_slot": 0,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 55,
+            "origin_id": 8,
+            "origin_slot": 1,
+            "target_id": -20,
+            "target_slot": 1,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 157,
+            "origin_id": 28,
+            "origin_slot": 0,
+            "target_id": -20,
+            "target_slot": 2,
+            "type": "NOISE"
+          },
+          {
+            "id": 142,
+            "origin_id": 13,
+            "origin_slot": 0,
+            "target_id": -20,
+            "target_slot": 3,
+            "type": "LATENT"
+          },
+          {
+            "id": 143,
+            "origin_id": 13,
+            "origin_slot": 1,
+            "target_id": -20,
+            "target_slot": 4,
+            "type": "LATENT"
+          }
+        ],
+        "extra": {
+          "workflowRendererVersion": "LG",
+          "ue_links": [],
+          "links_added_by_ue": []
+        }
+      },
+      {
+        "id": "7cf6430b-4784-4af1-8cde-9268e9465c62",
+        "version": 1,
+        "state": {
+          "lastGroupId": 6,
+          "lastNodeId": 104,
+          "lastLinkId": 258,
+          "lastRerouteId": 0
+        },
+        "revision": 0,
+        "config": {},
+        "name": "Stage #2",
+        "inputNode": {
+          "id": -10,
+          "bounding": [
+            2870,
+            3980,
+            128,
+            208
+          ]
+        },
+        "outputNode": {
+          "id": -20,
+          "bounding": [
+            4430,
+            3900,
+            128,
+            88
+          ]
+        },
+        "inputs": [
+          {
+            "id": "da8ac1d4-baaa-49af-a44f-51de815b8adc",
+            "name": "positive",
+            "type": "CONDITIONING",
+            "linkIds": [
+              228,
+              227
+            ],
+            "localized_name": "positive",
+            "pos": [
+              2974,
+              4004
+            ]
+          },
+          {
+            "id": "2a2ae901-93e9-4551-97e5-bf33db9a7761",
+            "name": "negative",
+            "type": "CONDITIONING",
+            "linkIds": [
+              230,
+              229
+            ],
+            "localized_name": "negative",
+            "pos": [
+              2974,
+              4024
+            ]
+          },
+          {
+            "id": "f6f33172-a93d-4505-a3c8-4e4e61488f94",
+            "name": "latent",
+            "type": "LATENT",
+            "linkIds": [
+              232
+            ],
+            "localized_name": "latent",
+            "label": "video_latent",
+            "pos": [
+              2974,
+              4044
+            ]
+          },
+          {
+            "id": "9d67923c-e4e8-4eb5-a91b-b37dbfb5882f",
+            "name": "vae",
+            "type": "VAE",
+            "linkIds": [
+              219,
+              218
+            ],
+            "localized_name": "vae",
+            "label": "video_vae",
+            "pos": [
+              2974,
+              4064
+            ]
+          },
+          {
+            "id": "c5f8e7de-87ec-4509-892c-8cc4e1f14575",
+            "name": "guide_data",
+            "type": "GUIDE_DATA",
+            "linkIds": [
+              151
+            ],
+            "localized_name": "guide_data",
+            "pos": [
+              2974,
+              4084
+            ]
+          },
+          {
+            "id": "c9c467d0-0426-4288-a31e-b41be1891bdc",
+            "name": "model",
+            "type": "MODEL",
+            "linkIds": [
+              158,
+              159
+            ],
+            "localized_name": "model",
+            "pos": [
+              2974,
+              4104
+            ]
+          },
+          {
+            "id": "1c4bd34a-4e48-455a-bd66-323524e5c2d8",
+            "name": "noise",
+            "type": "NOISE",
+            "linkIds": [
+              231
+            ],
+            "localized_name": "noise",
+            "pos": [
+              2974,
+              4124
+            ]
+          },
+          {
+            "id": "ef0cc4fb-4a9f-404b-a62c-92e04fd74171",
+            "name": "audio_latent",
+            "type": "LATENT",
+            "linkIds": [
+              233
+            ],
+            "localized_name": "audio_latent",
+            "pos": [
+              2974,
+              4144
+            ]
+          }
+        ],
+        "outputs": [
+          {
+            "id": "402aed7a-321d-48a8-a407-34f05a5ab1e2",
+            "name": "audio_latent",
+            "type": "LATENT",
+            "linkIds": [
+              202
+            ],
+            "localized_name": "audio_latent",
+            "pos": [
+              4454,
+              3924
+            ]
+          },
+          {
+            "id": "8fe53957-38d9-459e-a590-3ad4d96d3616",
+            "name": "latent",
+            "type": "LATENT",
+            "linkIds": [
+              208
+            ],
+            "localized_name": "latent",
+            "pos": [
+              4454,
+              3944
+            ]
+          }
+        ],
+        "widgets": [],
+        "nodes": [
+          {
+            "id": 55,
+            "type": "LTXVCropGuides",
+            "pos": [
+              3050,
+              3930
+            ],
+            "size": [
+              250,
+              70
+            ],
+            "flags": {},
+            "order": 9,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "positive",
+                "name": "positive",
+                "type": "CONDITIONING",
+                "link": 228
+              },
+              {
+                "localized_name": "negative",
+                "name": "negative",
+                "type": "CONDITIONING",
+                "link": 230
+              },
+              {
+                "localized_name": "latent",
+                "name": "latent",
+                "type": "LATENT",
+                "link": 232
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "positive",
+                "name": "positive",
+                "type": "CONDITIONING",
+                "links": [
+                  146
+                ]
+              },
+              {
+                "localized_name": "negative",
+                "name": "negative",
+                "type": "CONDITIONING",
+                "links": [
+                  147
+                ]
+              },
+              {
+                "localized_name": "latent",
+                "name": "latent",
+                "type": "LATENT",
+                "links": [
+                  135
+                ]
+              }
+            ],
+            "properties": {
+              "cnr_id": "comfy-core",
+              "ver": "0.16.4",
+              "Node name for S&R": "LTXVCropGuides",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              }
+            },
+            "widgets_values": [],
+            "color": "#222",
+            "bgcolor": "#000"
+          },
+          {
+            "id": 58,
+            "type": "LTXDirectorGuide",
+            "pos": [
+              3310,
+              3930
+            ],
+            "size": [
+              210,
+              190
+            ],
+            "flags": {},
+            "order": 10,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "positive",
+                "name": "positive",
+                "type": "CONDITIONING",
+                "link": 146
+              },
+              {
+                "localized_name": "negative",
+                "name": "negative",
+                "type": "CONDITIONING",
+                "link": 147
+              },
+              {
+                "localized_name": "vae",
+                "name": "vae",
+                "type": "VAE",
+                "link": 219
+              },
+              {
+                "localized_name": "latent",
+                "name": "latent",
+                "type": "LATENT",
+                "link": 150
+              },
+              {
+                "localized_name": "guide_data",
+                "name": "guide_data",
+                "type": "GUIDE_DATA",
+                "link": 151
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "positive",
+                "name": "positive",
+                "type": "CONDITIONING",
+                "links": [
+                  152
+                ]
+              },
+              {
+                "localized_name": "negative",
+                "name": "negative",
+                "type": "CONDITIONING",
+                "links": [
+                  153
+                ]
+              },
+              {
+                "localized_name": "latent",
+                "name": "latent",
+                "type": "LATENT",
+                "links": [
+                  154
+                ]
+              }
+            ],
+            "properties": {
+              "aux_id": "kijai/ComfyUI-PromptRelay",
+              "ver": "5cae3c00186ff2eb79771070f05a2c4e02f329bb",
+              "Node name for S&R": "LTXDirectorGuide",
+              "cnr_id": "whatdreamscost-comfyui",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              }
+            },
+            "widgets_values": [
+              1,
+              "bicubic"
+            ],
+            "color": "#222",
+            "bgcolor": "#000"
+          },
+          {
+            "id": 49,
+            "type": "CFGGuider",
+            "pos": [
+              3540,
+              3920
+            ],
+            "size": [
+              210,
+              100
+            ],
+            "flags": {},
+            "order": 5,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "model",
+                "name": "model",
+                "type": "MODEL",
+                "link": 158
+              },
+              {
+                "localized_name": "positive",
+                "name": "positive",
+                "type": "CONDITIONING",
+                "link": 152
+              },
+              {
+                "localized_name": "negative",
+                "name": "negative",
+                "type": "CONDITIONING",
+                "link": 153
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "GUIDER",
+                "name": "GUIDER",
+                "type": "GUIDER",
+                "links": [
+                  124
+                ]
+              }
+            ],
+            "properties": {
+              "cnr_id": "comfy-core",
+              "ver": "0.3.64",
+              "Node name for S&R": "CFGGuider",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              }
+            },
+            "widgets_values": [
+              1
+            ],
+            "color": "#222",
+            "bgcolor": "#000"
+          },
+          {
+            "id": 53,
+            "type": "KSamplerSelect",
+            "pos": [
+              3540,
+              4060
+            ],
+            "size": [
+              210,
+              60
+            ],
+            "flags": {},
+            "order": 0,
+            "mode": 0,
+            "inputs": [],
+            "outputs": [
+              {
+                "localized_name": "SAMPLER",
+                "name": "SAMPLER",
+                "type": "SAMPLER",
+                "links": [
+                  125
+                ]
+              }
+            ],
+            "properties": {
+              "cnr_id": "comfy-core",
+              "ver": "0.3.56",
+              "Node name for S&R": "KSamplerSelect",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              }
+            },
+            "widgets_values": [
+              "euler"
+            ],
+            "color": "#222",
+            "bgcolor": "#000"
+          },
+          {
+            "id": 47,
+            "type": "SamplerCustomAdvanced",
+            "pos": [
+              3760,
+              3920
+            ],
+            "size": [
+              230,
+              443.30791788856305
+            ],
+            "flags": {},
+            "order": 3,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "noise",
+                "name": "noise",
+                "type": "NOISE",
+                "link": 231
+              },
+              {
+                "localized_name": "guider",
+                "name": "guider",
+                "type": "GUIDER",
+                "link": 124
+              },
+              {
+                "localized_name": "sampler",
+                "name": "sampler",
+                "type": "SAMPLER",
+                "link": 125
+              },
+              {
+                "localized_name": "sigmas",
+                "name": "sigmas",
+                "type": "SIGMAS",
+                "link": 126
+              },
+              {
+                "localized_name": "latent_image",
+                "name": "latent_image",
+                "type": "LATENT",
+                "link": 127
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "output",
+                "name": "output",
+                "type": "LATENT",
+                "links": [
+                  180
+                ]
+              },
+              {
+                "localized_name": "denoised_output",
+                "name": "denoised_output",
+                "type": "LATENT",
+                "links": []
+              }
+            ],
+            "properties": {
+              "cnr_id": "comfy-core",
+              "ver": "0.3.60",
+              "Node name for S&R": "SamplerCustomAdvanced",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              }
+            },
+            "widgets_values": [],
+            "color": "#222",
+            "bgcolor": "#000"
+          },
+          {
+            "id": 57,
+            "type": "LatentUpscaleModelLoader",
+            "pos": [
+              3050,
+              4040
+            ],
+            "size": [
+              250,
+              70
+            ],
+            "flags": {},
+            "order": 1,
+            "mode": 0,
+            "inputs": [],
+            "outputs": [
+              {
+                "localized_name": "LATENT_UPSCALE_MODEL",
+                "name": "LATENT_UPSCALE_MODEL",
+                "type": "LATENT_UPSCALE_MODEL",
+                "links": [
+                  144
+                ]
+              }
+            ],
+            "properties": {
+              "cnr_id": "comfy-core",
+              "ver": "0.16.4",
+              "Node name for S&R": "LatentUpscaleModelLoader",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              }
+            },
+            "widgets_values": [
+              "ltx-2.3-spatial-upscaler-x2-1.1.safetensors"
+            ],
+            "color": "#222",
+            "bgcolor": "#000"
+          },
+          {
+            "id": 48,
+            "type": "LTXVSeparateAVLatent",
+            "pos": [
+              4000,
+              3920
+            ],
+            "size": [
+              200,
+              50
+            ],
+            "flags": {},
+            "order": 4,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "av_latent",
+                "name": "av_latent",
+                "type": "LATENT",
+                "link": 180
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "video_latent",
+                "name": "video_latent",
+                "type": "LATENT",
+                "links": [
+                  136
+                ]
+              },
+              {
+                "localized_name": "audio_latent",
+                "name": "audio_latent",
+                "type": "LATENT",
+                "links": [
+                  202
+                ]
+              }
+            ],
+            "properties": {
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "Node name for S&R": "LTXVSeparateAVLatent",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              }
+            },
+            "widgets_values": [],
+            "color": "#222",
+            "bgcolor": "#000"
+          },
+          {
+            "id": 52,
+            "type": "LTXVLatentUpsampler",
+            "pos": [
+              3050,
+              4150
+            ],
+            "size": [
+              250,
+              70
+            ],
+            "flags": {},
+            "order": 7,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "samples",
+                "name": "samples",
+                "type": "LATENT",
+                "link": 135
+              },
+              {
+                "localized_name": "upscale_model",
+                "name": "upscale_model",
+                "type": "LATENT_UPSCALE_MODEL",
+                "link": 144
+              },
+              {
+                "localized_name": "vae",
+                "name": "vae",
+                "type": "VAE",
+                "link": 218
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "LATENT",
+                "name": "LATENT",
+                "type": "LATENT",
+                "links": [
+                  150
+                ]
+              }
+            ],
+            "properties": {
+              "cnr_id": "comfy-core",
+              "ver": "0.14.1",
+              "Node name for S&R": "LTXVLatentUpsampler",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              }
+            },
+            "widgets_values": [],
+            "color": "#222",
+            "bgcolor": "#000"
+          },
+          {
+            "id": 54,
+            "type": "BasicScheduler",
+            "pos": [
+              3540,
+              4160
+            ],
+            "size": [
+              210,
+              110
+            ],
+            "flags": {},
+            "order": 8,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "model",
+                "name": "model",
+                "type": "MODEL",
+                "link": 159
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "SIGMAS",
+                "name": "SIGMAS",
+                "type": "SIGMAS",
+                "links": [
+                  126
+                ]
+              }
+            ],
+            "properties": {
+              "cnr_id": "comfy-core",
+              "ver": "0.16.4",
+              "Node name for S&R": "BasicScheduler",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              }
+            },
+            "widgets_values": [
+              "linear_quadratic",
+              4,
+              0.42
+            ],
+            "color": "#222",
+            "bgcolor": "#000"
+          },
+          {
+            "id": 50,
+            "type": "LTXVConcatAVLatent",
+            "pos": [
+              3310,
+              4160
+            ],
+            "size": [
+              210,
+              60
+            ],
+            "flags": {},
+            "order": 6,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "video_latent",
+                "name": "video_latent",
+                "type": "LATENT",
+                "link": 154
+              },
+              {
+                "localized_name": "audio_latent",
+                "name": "audio_latent",
+                "type": "LATENT",
+                "link": 233
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "latent",
+                "name": "latent",
+                "type": "LATENT",
+                "links": [
+                  127
+                ]
+              }
+            ],
+            "properties": {
+              "cnr_id": "comfy-core",
+              "ver": "0.7.0",
+              "Node name for S&R": "LTXVConcatAVLatent",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              }
+            },
+            "widgets_values": [],
+            "color": "#222",
+            "bgcolor": "#000"
+          },
+          {
+            "id": 14,
+            "type": "LTXVCropGuides",
+            "pos": [
+              4210,
+              3920
+            ],
+            "size": [
+              180,
+              70
+            ],
+            "flags": {},
+            "order": 2,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "positive",
+                "name": "positive",
+                "type": "CONDITIONING",
+                "link": 227
+              },
+              {
+                "localized_name": "negative",
+                "name": "negative",
+                "type": "CONDITIONING",
+                "link": 229
+              },
+              {
+                "localized_name": "latent",
+                "name": "latent",
+                "type": "LATENT",
+                "link": 136
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "positive",
+                "name": "positive",
+                "type": "CONDITIONING",
+                "links": null
+              },
+              {
+                "localized_name": "negative",
+                "name": "negative",
+                "type": "CONDITIONING",
+                "links": null
+              },
+              {
+                "localized_name": "latent",
+                "name": "latent",
+                "type": "LATENT",
+                "links": [
+                  208
+                ]
+              }
+            ],
+            "properties": {
+              "cnr_id": "comfy-core",
+              "ver": "0.19.3",
+              "Node name for S&R": "LTXVCropGuides",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              }
+            },
+            "widgets_values": [],
+            "color": "#222",
+            "bgcolor": "#000"
+          }
+        ],
+        "groups": [],
+        "links": [
+          {
+            "id": 146,
+            "origin_id": 55,
+            "origin_slot": 0,
+            "target_id": 58,
+            "target_slot": 0,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 147,
+            "origin_id": 55,
+            "origin_slot": 1,
+            "target_id": 58,
+            "target_slot": 1,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 150,
+            "origin_id": 52,
+            "origin_slot": 0,
+            "target_id": 58,
+            "target_slot": 3,
+            "type": "LATENT"
+          },
+          {
+            "id": 152,
+            "origin_id": 58,
+            "origin_slot": 0,
+            "target_id": 49,
+            "target_slot": 1,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 153,
+            "origin_id": 58,
+            "origin_slot": 1,
+            "target_id": 49,
+            "target_slot": 2,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 124,
+            "origin_id": 49,
+            "origin_slot": 0,
+            "target_id": 47,
+            "target_slot": 1,
+            "type": "GUIDER"
+          },
+          {
+            "id": 125,
+            "origin_id": 53,
+            "origin_slot": 0,
+            "target_id": 47,
+            "target_slot": 2,
+            "type": "SAMPLER"
+          },
+          {
+            "id": 126,
+            "origin_id": 54,
+            "origin_slot": 0,
+            "target_id": 47,
+            "target_slot": 3,
+            "type": "SIGMAS"
+          },
+          {
+            "id": 127,
+            "origin_id": 50,
+            "origin_slot": 0,
+            "target_id": 47,
+            "target_slot": 4,
+            "type": "LATENT"
+          },
+          {
+            "id": 180,
+            "origin_id": 47,
+            "origin_slot": 0,
+            "target_id": 48,
+            "target_slot": 0,
+            "type": "LATENT"
+          },
+          {
+            "id": 135,
+            "origin_id": 55,
+            "origin_slot": 2,
+            "target_id": 52,
+            "target_slot": 0,
+            "type": "LATENT"
+          },
+          {
+            "id": 144,
+            "origin_id": 57,
+            "origin_slot": 0,
+            "target_id": 52,
+            "target_slot": 1,
+            "type": "LATENT_UPSCALE_MODEL"
+          },
+          {
+            "id": 154,
+            "origin_id": 58,
+            "origin_slot": 2,
+            "target_id": 50,
+            "target_slot": 0,
+            "type": "LATENT"
+          },
+          {
+            "id": 136,
+            "origin_id": 48,
+            "origin_slot": 0,
+            "target_id": 14,
+            "target_slot": 2,
+            "type": "LATENT"
+          },
+          {
+            "id": 228,
+            "origin_id": -10,
+            "origin_slot": 0,
+            "target_id": 55,
+            "target_slot": 0,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 227,
+            "origin_id": -10,
+            "origin_slot": 0,
+            "target_id": 14,
+            "target_slot": 0,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 230,
+            "origin_id": -10,
+            "origin_slot": 1,
+            "target_id": 55,
+            "target_slot": 1,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 229,
+            "origin_id": -10,
+            "origin_slot": 1,
+            "target_id": 14,
+            "target_slot": 1,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 232,
+            "origin_id": -10,
+            "origin_slot": 2,
+            "target_id": 55,
+            "target_slot": 2,
+            "type": "LATENT"
+          },
+          {
+            "id": 219,
+            "origin_id": -10,
+            "origin_slot": 3,
+            "target_id": 58,
+            "target_slot": 2,
+            "type": "VAE"
+          },
+          {
+            "id": 218,
+            "origin_id": -10,
+            "origin_slot": 3,
+            "target_id": 52,
+            "target_slot": 2,
+            "type": "VAE"
+          },
+          {
+            "id": 151,
+            "origin_id": -10,
+            "origin_slot": 4,
+            "target_id": 58,
+            "target_slot": 4,
+            "type": "GUIDE_DATA"
+          },
+          {
+            "id": 158,
+            "origin_id": -10,
+            "origin_slot": 5,
+            "target_id": 49,
+            "target_slot": 0,
+            "type": "MODEL"
+          },
+          {
+            "id": 159,
+            "origin_id": -10,
+            "origin_slot": 5,
+            "target_id": 54,
+            "target_slot": 0,
+            "type": "MODEL"
+          },
+          {
+            "id": 231,
+            "origin_id": -10,
+            "origin_slot": 6,
+            "target_id": 47,
+            "target_slot": 0,
+            "type": "NOISE"
+          },
+          {
+            "id": 233,
+            "origin_id": -10,
+            "origin_slot": 7,
+            "target_id": 50,
+            "target_slot": 1,
+            "type": "LATENT"
+          },
+          {
+            "id": 202,
+            "origin_id": 48,
+            "origin_slot": 1,
+            "target_id": -20,
+            "target_slot": 0,
+            "type": "LATENT"
+          },
+          {
+            "id": 208,
+            "origin_id": 14,
+            "origin_slot": 2,
+            "target_id": -20,
+            "target_slot": 1,
+            "type": "LATENT"
+          }
+        ],
+        "extra": {
+          "workflowRendererVersion": "LG",
+          "ue_links": [],
+          "links_added_by_ue": []
+        }
+      },
+      {
+        "id": "739520a4-718f-490f-87d1-34ffbca98e3f",
+        "version": 1,
+        "state": {
+          "lastGroupId": 6,
+          "lastNodeId": 104,
+          "lastLinkId": 258,
+          "lastRerouteId": 0
+        },
+        "revision": 0,
+        "config": {},
+        "name": "Decode",
+        "inputNode": {
+          "id": -10,
+          "bounding": [
+            3330,
+            4105,
+            120,
+            140
+          ]
+        },
+        "outputNode": {
+          "id": -20,
+          "bounding": [
+            3780,
+            4145,
+            120,
+            60
+          ]
+        },
+        "inputs": [
+          {
+            "id": "35c40a03-3855-445e-a691-ae0ada359280",
+            "name": "samples",
+            "type": "LATENT",
+            "linkIds": [
+              242
+            ],
+            "localized_name": "samples",
+            "label": "audio_latent",
+            "pos": [
+              3430,
+              4125
+            ]
+          },
+          {
+            "id": "ddfb8ed1-1fd2-4086-ad94-d816dab3b6bb",
+            "name": "audio_vae",
+            "type": "VAE",
+            "linkIds": [
+              214
+            ],
+            "localized_name": "audio_vae",
+            "label": "audio_vae",
+            "pos": [
+              3430,
+              4145
+            ]
+          },
+          {
+            "id": "458157ba-efe8-4aa2-847e-be97d78a6873",
+            "name": "samples_1",
+            "type": "LATENT",
+            "linkIds": [
+              243
+            ],
+            "localized_name": "samples_1",
+            "label": "video_latent",
+            "pos": [
+              3430,
+              4165
+            ]
+          },
+          {
+            "id": "b02f1f71-c594-437f-8dda-4bb0f19c2e3e",
+            "name": "vae",
+            "type": "VAE",
+            "linkIds": [
+              217
+            ],
+            "localized_name": "vae",
+            "label": "video_vae",
+            "pos": [
+              3430,
+              4185
+            ]
+          },
+          {
+            "id": "83aa76da-c7d7-41b5-a3d6-4942595be90c",
+            "name": "fps",
+            "type": "FLOAT",
+            "linkIds": [
+              121
+            ],
+            "localized_name": "fps",
+            "pos": [
+              3430,
+              4205
+            ]
+          }
+        ],
+        "outputs": [
+          {
+            "id": "7d63e3c3-78d0-4613-9631-0fa830d1bf9a",
+            "name": "VIDEO",
+            "type": "VIDEO",
+            "linkIds": [
+              56
+            ],
+            "localized_name": "VIDEO",
+            "pos": [
+              3800,
+              4165
+            ]
+          }
+        ],
+        "widgets": [],
+        "nodes": [
+          {
+            "id": 16,
+            "type": "LTXVAudioVAEDecode",
+            "pos": [
+              3510,
+              4060
+            ],
+            "size": [
+              210,
+              50
+            ],
+            "flags": {},
+            "order": 1,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "samples",
+                "name": "samples",
+                "type": "LATENT",
+                "link": 242
+              },
+              {
+                "label": "Audio VAE",
+                "localized_name": "audio_vae",
+                "name": "audio_vae",
+                "type": "VAE",
+                "link": 214
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "Audio",
+                "name": "Audio",
+                "type": "AUDIO",
+                "links": [
+                  25
+                ]
+              }
+            ],
+            "properties": {
+              "cnr_id": "comfy-core",
+              "ver": "0.16.0",
+              "Node name for S&R": "LTXVAudioVAEDecode",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              }
+            },
+            "widgets_values": [],
+            "color": "#222",
+            "bgcolor": "#000"
+          },
+          {
+            "id": 15,
+            "type": "VAEDecode",
+            "pos": [
+              3510,
+              4150
+            ],
+            "size": [
+              210,
+              50
+            ],
+            "flags": {},
+            "order": 0,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "samples",
+                "name": "samples",
+                "type": "LATENT",
+                "link": 243
+              },
+              {
+                "localized_name": "vae",
+                "name": "vae",
+                "type": "VAE",
+                "link": 217
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "IMAGE",
+                "name": "IMAGE",
+                "type": "IMAGE",
+                "links": [
+                  24
+                ]
+              }
+            ],
+            "properties": {
+              "cnr_id": "comfy-core",
+              "ver": "0.9.1",
+              "Node name for S&R": "VAEDecode",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              }
+            },
+            "widgets_values": [],
+            "color": "#222",
+            "bgcolor": "#000"
+          },
+          {
+            "id": 17,
+            "type": "CreateVideo",
+            "pos": [
+              3510,
+              4240
+            ],
+            "size": [
+              210,
+              80
+            ],
+            "flags": {},
+            "order": 2,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "images",
+                "name": "images",
+                "type": "IMAGE",
+                "link": 24
+              },
+              {
+                "localized_name": "audio",
+                "name": "audio",
+                "shape": 7,
+                "type": "AUDIO",
+                "link": 25
+              },
+              {
+                "localized_name": "fps",
+                "name": "fps",
+                "type": "FLOAT",
+                "widget": {
+                  "name": "fps"
+                },
+                "link": 121
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "VIDEO",
+                "name": "VIDEO",
+                "type": "VIDEO",
+                "links": [
+                  56
+                ]
+              }
+            ],
+            "properties": {
+              "cnr_id": "comfy-core",
+              "ver": "0.19.3",
+              "Node name for S&R": "CreateVideo",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              }
+            },
+            "widgets_values": [
+              24
+            ],
+            "color": "#222",
+            "bgcolor": "#000"
+          }
+        ],
+        "groups": [],
+        "links": [
+          {
+            "id": 24,
+            "origin_id": 15,
+            "origin_slot": 0,
+            "target_id": 17,
+            "target_slot": 0,
+            "type": "IMAGE"
+          },
+          {
+            "id": 25,
+            "origin_id": 16,
+            "origin_slot": 0,
+            "target_id": 17,
+            "target_slot": 1,
+            "type": "AUDIO"
+          },
+          {
+            "id": 242,
+            "origin_id": -10,
+            "origin_slot": 0,
+            "target_id": 16,
+            "target_slot": 0,
+            "type": "LATENT"
+          },
+          {
+            "id": 214,
+            "origin_id": -10,
+            "origin_slot": 1,
+            "target_id": 16,
+            "target_slot": 1,
+            "type": "VAE"
+          },
+          {
+            "id": 243,
+            "origin_id": -10,
+            "origin_slot": 2,
+            "target_id": 15,
+            "target_slot": 0,
+            "type": "LATENT"
+          },
+          {
+            "id": 217,
+            "origin_id": -10,
+            "origin_slot": 3,
+            "target_id": 15,
+            "target_slot": 1,
+            "type": "VAE"
+          },
+          {
+            "id": 121,
+            "origin_id": -10,
+            "origin_slot": 4,
+            "target_id": 17,
+            "target_slot": 2,
+            "type": "FLOAT"
+          },
+          {
+            "id": 56,
+            "origin_id": 17,
+            "origin_slot": 0,
+            "target_id": -20,
+            "target_slot": 0,
+            "type": "VIDEO"
+          }
+        ],
+        "extra": {
+          "workflowRendererVersion": "LG",
+          "ue_links": [],
+          "links_added_by_ue": []
+        }
+      }
+    ]
+  },
+  "config": {},
+  "extra": {
+    "frontendVersion": "1.43.18",
+    "VHS_latentpreview": false,
+    "VHS_latentpreviewrate": 0,
+    "VHS_MetadataImage": true,
+    "VHS_KeepIntermediate": true,
+    "workflowRendererVersion": "LG",
+    "ue_links": [],
+    "links_added_by_ue": [],
+    "ds": {
+      "scale": 0.593315663706161,
+      "offset": [
+        -390.85785408136417,
+        -3933.2483114204406
+      ]
+    }
+  },
+  "version": 0.4
+}

--- a/example_workflows/LTX Director Example.json
+++ b/example_workflows/LTX Director Example.json
@@ -1,0 +1,3985 @@
+{
+  "id": "c92620ea-60b4-4f41-a78f-621383a62c2b",
+  "revision": 0,
+  "last_node_id": 108,
+  "last_link_id": 258,
+  "nodes": [
+    {
+      "id": 108,
+      "type": "MarkdownNote",
+      "pos": [
+        430,
+        3730
+      ],
+      "size": [
+        340,
+        290
+      ],
+      "flags": {},
+      "order": 0,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [],
+      "title": "✨ Built-in Prompt Generator",
+      "properties": {
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "## ✨ Built-in Prompt Generator\n\nNo extra nodes needed! LTX Director has a built-in **✨ Prompts** button in its toolbar.\n\n### How to use:\n1. Add a reference image to a segment in the timeline\n2. Click **✨ Prompts** — prompts are filled automatically\n3. Configure in **⚙ Settings → Prompt Writer**\n\n### Models supported:\n- **HuggingFace** (auto-download): Qwen2.5-VL 3B or 7B\n- **Local GGUF**: set *Local Path* to your `.gguf` file or its folder. If a `mmproj-*.gguf` is in the same folder, vision is enabled automatically\n\n### Style Directives (in Settings):\nControl **Style Preset**, **Shot Angle**, **Camera Movement**, and add a free-text **Extra Instruction** to steer every generated prompt."
+      ],
+      "color": "#1a2a1a",
+      "bgcolor": "#0a1a0a"
+    },
+    {
+      "id": 96,
+      "type": "739520a4-718f-490f-87d1-34ffbca98e3f",
+      "pos": [
+        3000,
+        4620
+      ],
+      "size": [
+        210,
+        130
+      ],
+      "flags": {},
+      "order": 9,
+      "mode": 0,
+      "inputs": [
+        {
+          "label": "audio_latent",
+          "name": "samples",
+          "type": "LATENT",
+          "link": 244
+        },
+        {
+          "label": "audio_vae",
+          "name": "audio_vae",
+          "type": "VAE",
+          "link": 245
+        },
+        {
+          "label": "video_latent",
+          "name": "samples_1",
+          "type": "LATENT",
+          "link": 246
+        },
+        {
+          "label": "video_vae",
+          "name": "vae",
+          "type": "VAE",
+          "link": 247
+        },
+        {
+          "name": "fps",
+          "type": "FLOAT",
+          "widget": {
+            "name": "fps"
+          },
+          "link": 248
+        }
+      ],
+      "outputs": [
+        {
+          "name": "VIDEO",
+          "type": "VIDEO",
+          "links": [
+            249
+          ]
+        }
+      ],
+      "properties": {
+        "proxyWidgets": [
+          [
+            "17",
+            "fps"
+          ]
+        ],
+        "cnr_id": "comfy-core",
+        "ver": "0.19.3",
+        "ue_properties": {
+          "widget_ue_connectable": {
+            "fps": true
+          },
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [],
+      "color": "#222",
+      "bgcolor": "#000"
+    },
+    {
+      "id": 92,
+      "type": "MarkdownNote",
+      "pos": [
+        1430,
+        4220
+      ],
+      "size": [
+        400,
+        530
+      ],
+      "flags": {},
+      "order": 4,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [],
+      "title": "FAQ",
+      "properties": {
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "# FAQ\n\n**How do I use this??**\n\nI'll be posting tutorials on my YouTube channel soon!\n<https://www.youtube.com/@WhatDreamsCost/>\n\n**Where do I download these models??**\n\nThere is a good list of models and download links here: <https://github.com/wildminder/awesome-ltx2?tab=readme-ov-file>\n\nAlso the latest v1.1 spatial upscaler can be found here: <https://huggingface.co/Lightricks/LTX-2.3/tree/main>\n\nThe tiny vae (taeltx2_3.safetensors) is found here:\n<https://huggingface.co/Kijai/LTX2.3_comfy/blob/main/vae/taeltx2_3.safetensors>\n\n**I'm getting errors when running this workflow!**\n\nDouble check that you have all of the correct models loaded. This is using the newest version of 2x upscaler (v1.1). You can change it to the older one under the Model Loader.\n\n**How can I support you??**\n\nHelp me get a job. I'm unemployed and literally broke. (seriously, i'll even scrub toilets for minimum wage)\n\nOr follow me on my socials :)\n\n<https://x.com/WhatDreamsCost>\n\n<https://www.youtube.com/@WhatDreamsCost/>\n\n<https://www.instagram.com/whatdreamscost/>"
+      ],
+      "color": "#322",
+      "bgcolor": "#533"
+    },
+    {
+      "id": 30,
+      "type": "SaveVideo",
+      "pos": [
+        3230,
+        3970
+      ],
+      "size": [
+        690,
+        1133
+      ],
+      "flags": {},
+      "order": 10,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "video",
+          "type": "VIDEO",
+          "link": 249
+        }
+      ],
+      "outputs": [],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.19.3",
+        "Node name for S&R": "SaveVideo",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "video/LTX_Director",
+        "auto",
+        "auto"
+      ],
+      "color": "#222",
+      "bgcolor": "#000"
+    },
+    {
+      "id": 94,
+      "type": "4b017e47-bf16-441b-ad03-edce978b3be3",
+      "pos": [
+        3000,
+        3970
+      ],
+      "size": [
+        210,
+        477.27859237536654
+      ],
+      "flags": {},
+      "order": 7,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "model",
+          "type": "MODEL",
+          "link": 220
+        },
+        {
+          "name": "audio_latent",
+          "type": "LATENT",
+          "link": 221
+        },
+        {
+          "name": "vae",
+          "type": "VAE",
+          "link": 222
+        },
+        {
+          "label": "video_latent",
+          "name": "latent",
+          "type": "LATENT",
+          "link": 223
+        },
+        {
+          "name": "guide_data",
+          "type": "GUIDE_DATA",
+          "link": 224
+        },
+        {
+          "name": "positive",
+          "type": "CONDITIONING",
+          "link": 225
+        },
+        {
+          "name": "frame_rate",
+          "type": "FLOAT",
+          "widget": {
+            "name": "frame_rate"
+          },
+          "link": 226
+        },
+        {
+          "name": "noise_seed",
+          "type": "INT",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "positive",
+          "type": "CONDITIONING",
+          "links": [
+            234
+          ]
+        },
+        {
+          "name": "negative",
+          "type": "CONDITIONING",
+          "links": [
+            235
+          ]
+        },
+        {
+          "name": "NOISE",
+          "type": "NOISE",
+          "links": [
+            240
+          ]
+        },
+        {
+          "name": "video_latent",
+          "type": "LATENT",
+          "links": [
+            236
+          ]
+        },
+        {
+          "name": "audio_latent",
+          "type": "LATENT",
+          "links": [
+            241
+          ]
+        }
+      ],
+      "properties": {
+        "proxyWidgets": [
+          [
+            "5",
+            "frame_rate"
+          ]
+        ],
+        "cnr_id": "comfy-core",
+        "ver": "0.19.3",
+        "ue_properties": {
+          "widget_ue_connectable": {
+            "frame_rate": true
+          },
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [],
+      "color": "#222",
+      "bgcolor": "#000"
+    },
+    {
+      "id": 95,
+      "type": "7cf6430b-4784-4af1-8cde-9268e9465c62",
+      "pos": [
+        3000,
+        4290
+      ],
+      "size": [
+        210,
+        473.27859237536654
+      ],
+      "flags": {},
+      "order": 8,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "positive",
+          "type": "CONDITIONING",
+          "link": 234
+        },
+        {
+          "name": "negative",
+          "type": "CONDITIONING",
+          "link": 235
+        },
+        {
+          "label": "video_latent",
+          "name": "latent",
+          "type": "LATENT",
+          "link": 236
+        },
+        {
+          "label": "video_vae",
+          "name": "vae",
+          "type": "VAE",
+          "link": 237
+        },
+        {
+          "name": "guide_data",
+          "type": "GUIDE_DATA",
+          "link": 238
+        },
+        {
+          "name": "model",
+          "type": "MODEL",
+          "link": 239
+        },
+        {
+          "name": "noise",
+          "type": "NOISE",
+          "link": 240
+        },
+        {
+          "name": "audio_latent",
+          "type": "LATENT",
+          "link": 241
+        }
+      ],
+      "outputs": [
+        {
+          "name": "audio_latent",
+          "type": "LATENT",
+          "links": [
+            244
+          ]
+        },
+        {
+          "name": "latent",
+          "type": "LATENT",
+          "links": [
+            246
+          ]
+        }
+      ],
+      "properties": {
+        "proxyWidgets": [],
+        "cnr_id": "comfy-core",
+        "ver": "0.19.3",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [],
+      "color": "#222",
+      "bgcolor": "#000"
+    },
+    {
+      "id": 46,
+      "type": "LTXDirector",
+      "pos": [
+        1877.2979797979797,
+        3970
+      ],
+      "size": [
+        1120,
+        801
+      ],
+      "flags": {},
+      "order": 6,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "model",
+          "type": "MODEL",
+          "link": 212
+        },
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": 213
+        },
+        {
+          "name": "audio_vae",
+          "shape": 7,
+          "type": "VAE",
+          "link": 215
+        },
+        {
+          "name": "optional_latent",
+          "shape": 7,
+          "type": "LATENT",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "model",
+          "type": "MODEL",
+          "links": [
+            220,
+            239
+          ]
+        },
+        {
+          "name": "positive",
+          "type": "CONDITIONING",
+          "links": [
+            225
+          ]
+        },
+        {
+          "name": "video_latent",
+          "type": "LATENT",
+          "links": [
+            223
+          ]
+        },
+        {
+          "name": "audio_latent",
+          "type": "LATENT",
+          "links": [
+            221
+          ]
+        },
+        {
+          "name": "guide_data",
+          "type": "GUIDE_DATA",
+          "links": [
+            224,
+            238
+          ]
+        },
+        {
+          "name": "frame_rate",
+          "type": "FLOAT",
+          "links": [
+            226,
+            248
+          ]
+        },
+        {
+          "name": "combined_audio",
+          "type": "AUDIO",
+          "links": []
+        }
+      ],
+      "properties": {
+        "aux_id": "kijai/ComfyUI-PromptRelay",
+        "ver": "5cae3c00186ff2eb79771070f05a2c4e02f329bb",
+        "Node name for S&R": "LTXDirector",
+        "cnr_id": "whatdreamscost-comfyui",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "",
+        240,
+        10,
+        "{\"segments\":[{\"id\":\"seg1\",\"start\":0,\"length\":120,\"prompt\":\"\",\"type\":\"image\",\"imageFile\":\"\",\"imageB64\":\"\"},{\"id\":\"seg2\",\"start\":120,\"length\":120,\"prompt\":\"\",\"type\":\"text\"}],\"audioSegments\":[]}",
+        "",
+        "120,120",
+        0.001,
+        "1.00,1.00",
+        false,
+        24,
+        "seconds",
+        0,
+        0,
+        "maintain aspect ratio",
+        32,
+        18,
+        ""
+      ]
+    },
+    {
+      "id": 93,
+      "type": "dc399e64-01cd-40b2-9337-972428cc66de",
+      "pos": [
+        1263.0744949494963,
+        4009.785353535356
+      ],
+      "size": [
+        400,
+        190
+      ],
+      "flags": {},
+      "order": 5,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "label": "model",
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": [
+            212
+          ]
+        },
+        {
+          "label": "clip",
+          "name": "CLIP",
+          "type": "CLIP",
+          "links": [
+            213
+          ]
+        },
+        {
+          "label": "audio_vae",
+          "name": "VAE",
+          "type": "VAE",
+          "links": [
+            215,
+            245
+          ]
+        },
+        {
+          "label": "video_vae",
+          "name": "VAE_1",
+          "type": "VAE",
+          "links": [
+            222,
+            237,
+            247
+          ]
+        }
+      ],
+      "properties": {
+        "proxyWidgets": [
+          [
+            "77",
+            "ckpt_name"
+          ],
+          [
+            "84",
+            "clip_name1"
+          ],
+          [
+            "4",
+            "vae_name"
+          ],
+          [
+            "3",
+            "vae_name"
+          ]
+        ],
+        "cnr_id": "comfy-core",
+        "ver": "0.19.3",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [],
+      "color": "#222",
+      "bgcolor": "#000"
+    }
+  ],
+  "links": [
+    [
+      212,
+      93,
+      0,
+      46,
+      0,
+      "MODEL"
+    ],
+    [
+      213,
+      93,
+      1,
+      46,
+      1,
+      "CLIP"
+    ],
+    [
+      215,
+      93,
+      2,
+      46,
+      2,
+      "VAE"
+    ],
+    [
+      220,
+      46,
+      0,
+      94,
+      0,
+      "MODEL"
+    ],
+    [
+      221,
+      46,
+      3,
+      94,
+      1,
+      "LATENT"
+    ],
+    [
+      222,
+      93,
+      3,
+      94,
+      2,
+      "VAE"
+    ],
+    [
+      223,
+      46,
+      2,
+      94,
+      3,
+      "LATENT"
+    ],
+    [
+      224,
+      46,
+      4,
+      94,
+      4,
+      "GUIDE_DATA"
+    ],
+    [
+      225,
+      46,
+      1,
+      94,
+      5,
+      "CONDITIONING"
+    ],
+    [
+      226,
+      46,
+      5,
+      94,
+      6,
+      "FLOAT"
+    ],
+    [
+      234,
+      94,
+      0,
+      95,
+      0,
+      "CONDITIONING"
+    ],
+    [
+      235,
+      94,
+      1,
+      95,
+      1,
+      "CONDITIONING"
+    ],
+    [
+      236,
+      94,
+      3,
+      95,
+      2,
+      "LATENT"
+    ],
+    [
+      237,
+      93,
+      3,
+      95,
+      3,
+      "VAE"
+    ],
+    [
+      238,
+      46,
+      4,
+      95,
+      4,
+      "GUIDE_DATA"
+    ],
+    [
+      239,
+      46,
+      0,
+      95,
+      5,
+      "MODEL"
+    ],
+    [
+      240,
+      94,
+      2,
+      95,
+      6,
+      "NOISE"
+    ],
+    [
+      241,
+      94,
+      4,
+      95,
+      7,
+      "LATENT"
+    ],
+    [
+      244,
+      95,
+      0,
+      96,
+      0,
+      "LATENT"
+    ],
+    [
+      245,
+      93,
+      2,
+      96,
+      1,
+      "VAE"
+    ],
+    [
+      246,
+      95,
+      1,
+      96,
+      2,
+      "LATENT"
+    ],
+    [
+      247,
+      93,
+      3,
+      96,
+      3,
+      "VAE"
+    ],
+    [
+      248,
+      46,
+      5,
+      96,
+      4,
+      "FLOAT"
+    ],
+    [
+      249,
+      96,
+      0,
+      30,
+      0,
+      "VIDEO"
+    ]
+  ],
+  "groups": [],
+  "definitions": {
+    "subgraphs": [
+      {
+        "id": "dc399e64-01cd-40b2-9337-972428cc66de",
+        "version": 1,
+        "state": {
+          "lastGroupId": 6,
+          "lastNodeId": 104,
+          "lastLinkId": 258,
+          "lastRerouteId": 0
+        },
+        "revision": 0,
+        "config": {},
+        "name": "Model Loader",
+        "inputNode": {
+          "id": -10,
+          "bounding": [
+            1060,
+            4265,
+            128,
+            48
+          ]
+        },
+        "outputNode": {
+          "id": -20,
+          "bounding": [
+            1870,
+            4225,
+            128,
+            128
+          ]
+        },
+        "inputs": [],
+        "outputs": [
+          {
+            "id": "68f91346-0127-4451-a92f-5cfb56fc7f02",
+            "name": "MODEL",
+            "type": "MODEL",
+            "linkIds": [
+              199
+            ],
+            "localized_name": "MODEL",
+            "label": "model",
+            "pos": [
+              1894,
+              4249
+            ]
+          },
+          {
+            "id": "d50bc485-29c2-44a9-9653-fbb738989bdc",
+            "name": "CLIP",
+            "type": "CLIP",
+            "linkIds": [
+              254
+            ],
+            "localized_name": "CLIP",
+            "label": "clip",
+            "pos": [
+              1894,
+              4269
+            ]
+          },
+          {
+            "id": "cfbbcf84-8477-40b1-a7ba-318c8d3b03a0",
+            "name": "VAE",
+            "type": "VAE",
+            "linkIds": [
+              58,
+              58
+            ],
+            "localized_name": "VAE",
+            "label": "audio_vae",
+            "pos": [
+              1894,
+              4289
+            ]
+          },
+          {
+            "id": "815c9c85-34bc-49fc-8161-aca22b170346",
+            "name": "VAE_1",
+            "type": "VAE",
+            "linkIds": [
+              16,
+              16,
+              16,
+              16
+            ],
+            "localized_name": "VAE_1",
+            "label": "video_vae",
+            "pos": [
+              1894,
+              4309
+            ]
+          }
+        ],
+        "widgets": [],
+        "nodes": [
+          {
+            "id": 78,
+            "type": "VAELoaderKJ",
+            "pos": [
+              1530,
+              3870
+            ],
+            "size": [
+              270,
+              110
+            ],
+            "flags": {},
+            "order": 0,
+            "mode": 0,
+            "inputs": [],
+            "outputs": [
+              {
+                "localized_name": "VAE",
+                "name": "VAE",
+                "type": "VAE",
+                "links": [
+                  196
+                ]
+              }
+            ],
+            "title": "Tiny VAELoader KJ",
+            "properties": {
+              "cnr_id": "comfyui-kjnodes",
+              "ver": "1.2.5",
+              "Node name for S&R": "VAELoaderKJ",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              }
+            },
+            "widgets_values": [
+              "taeltx2_3.safetensors",
+              "main_device",
+              "bf16"
+            ],
+            "color": "#222",
+            "bgcolor": "#000"
+          },
+          {
+            "id": 4,
+            "type": "VAELoaderKJ",
+            "pos": [
+              1530,
+              4470
+            ],
+            "size": [
+              260,
+              110
+            ],
+            "flags": {},
+            "order": 1,
+            "mode": 0,
+            "inputs": [
+              {
+                "label": "audio_vae",
+                "localized_name": "vae_name",
+                "name": "vae_name",
+                "type": "COMBO",
+                "widget": {
+                  "name": "vae_name"
+                },
+                "link": null
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "VAE",
+                "name": "VAE",
+                "type": "VAE",
+                "links": [
+                  58
+                ]
+              }
+            ],
+            "title": "Audio VAELoader",
+            "properties": {
+              "cnr_id": "comfyui-kjnodes",
+              "ver": "487c7d86a0230aae3d8c0a37d517159b73834f85",
+              "Node name for S&R": "VAELoaderKJ",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              }
+            },
+            "widgets_values": [
+              "LTX23_audio_vae_bf16.safetensors",
+              "main_device",
+              "bf16"
+            ],
+            "color": "#222",
+            "bgcolor": "#000"
+          },
+          {
+            "id": 3,
+            "type": "VAELoaderKJ",
+            "pos": [
+              1530,
+              4620
+            ],
+            "size": [
+              260,
+              110
+            ],
+            "flags": {},
+            "order": 2,
+            "mode": 0,
+            "inputs": [
+              {
+                "label": "video_vae",
+                "localized_name": "vae_name",
+                "name": "vae_name",
+                "type": "COMBO",
+                "widget": {
+                  "name": "vae_name"
+                },
+                "link": null
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "VAE",
+                "name": "VAE",
+                "type": "VAE",
+                "links": [
+                  16
+                ]
+              }
+            ],
+            "title": "Video VAELoader",
+            "properties": {
+              "cnr_id": "comfyui-kjnodes",
+              "ver": "1.2.5",
+              "Node name for S&R": "VAELoaderKJ",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              }
+            },
+            "widgets_values": [
+              "LTX23_video_vae_bf16.safetensors",
+              "main_device",
+              "bf16"
+            ],
+            "color": "#222",
+            "bgcolor": "#000"
+          },
+          {
+            "id": 84,
+            "type": "DualCLIPLoader",
+            "pos": [
+              1530,
+              4290
+            ],
+            "size": [
+              270,
+              130
+            ],
+            "flags": {},
+            "order": 3,
+            "mode": 0,
+            "inputs": [
+              {
+                "label": "text_encoder",
+                "localized_name": "clip_name1",
+                "name": "clip_name1",
+                "type": "COMBO",
+                "widget": {
+                  "name": "clip_name1"
+                },
+                "link": null
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "CLIP",
+                "name": "CLIP",
+                "type": "CLIP",
+                "links": [
+                  253
+                ]
+              }
+            ],
+            "properties": {
+              "cnr_id": "comfy-core",
+              "ver": "0.19.3",
+              "Node name for S&R": "DualCLIPLoader",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              }
+            },
+            "widgets_values": [
+              "gemma_3_12B_it_heretic_fp8_e4m3fn.safetensors",
+              "ltx-2.3_text_projection_bf16.safetensors",
+              "ltxv",
+              "default"
+            ],
+            "color": "#222",
+            "bgcolor": "#000"
+          },
+          {
+            "id": 101,
+            "type": "Power Lora Loader (rgthree)",
+            "pos": [
+              183.20476390844237,
+              2852.236802764441
+            ],
+            "size": [
+              340.519921875,
+              622
+            ],
+            "flags": {},
+            "order": 4,
+            "mode": 0,
+            "inputs": [
+              {
+                "dir": 3,
+                "name": "model",
+                "type": "MODEL",
+                "link": null
+              },
+              {
+                "dir": 3,
+                "name": "clip",
+                "type": "CLIP",
+                "link": null
+              }
+            ],
+            "outputs": [
+              {
+                "dir": 4,
+                "name": "MODEL",
+                "shape": 3,
+                "type": "MODEL",
+                "links": null
+              },
+              {
+                "dir": 4,
+                "name": "CLIP",
+                "shape": 3,
+                "type": "CLIP",
+                "links": null
+              }
+            ],
+            "properties": {
+              "cnr_id": "rgthree-comfy",
+              "ver": "738105af5fb14e96fbecaf406dc356e284797e8c",
+              "Show Strengths": "Single Strength",
+              "Match": "",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "input_ue_unconnectable": {},
+                "version": "7.8"
+              }
+            },
+            "widgets_values": [
+              {},
+              {
+                "type": "PowerLoraLoaderHeaderWidget"
+              },
+              {
+                "on": true,
+                "lora": "LTX2\\LTX2.3_reasoning_I2V_V3.safetensors",
+                "strength": 0.5,
+                "strengthTwo": null
+              },
+              {
+                "on": true,
+                "lora": "LTX2\\DR34ML4Y_LTXXX_PREVIEW_RC1.safetensors",
+                "strength": 0.5,
+                "strengthTwo": null
+              },
+              {},
+              ""
+            ]
+          },
+          {
+            "id": 77,
+            "type": "CheckpointLoaderSimple",
+            "pos": [
+              1175.9530791788861,
+              4016.4418377321604
+            ],
+            "size": [
+              270,
+              100
+            ],
+            "flags": {},
+            "order": 5,
+            "mode": 0,
+            "inputs": [
+              {
+                "label": "model",
+                "localized_name": "ckpt_name",
+                "name": "ckpt_name",
+                "type": "COMBO",
+                "widget": {
+                  "name": "ckpt_name"
+                },
+                "link": null
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "MODEL",
+                "name": "MODEL",
+                "type": "MODEL",
+                "links": [
+                  255
+                ]
+              },
+              {
+                "localized_name": "CLIP",
+                "name": "CLIP",
+                "type": "CLIP",
+                "links": null
+              },
+              {
+                "localized_name": "VAE",
+                "name": "VAE",
+                "type": "VAE",
+                "links": null
+              }
+            ],
+            "properties": {
+              "cnr_id": "comfy-core",
+              "ver": "0.17.2",
+              "Node name for S&R": "CheckpointLoaderSimple",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              }
+            },
+            "widgets_values": [
+              "ltx2310eros_beta.safetensors"
+            ],
+            "color": "#222",
+            "bgcolor": "#000"
+          },
+          {
+            "id": 79,
+            "type": "LTX2SamplingPreviewOverride",
+            "pos": [
+              1530,
+              4020
+            ],
+            "size": [
+              270,
+              100
+            ],
+            "flags": {},
+            "order": 6,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "model",
+                "name": "model",
+                "type": "MODEL",
+                "link": 255
+              },
+              {
+                "localized_name": "latent_upscale_model",
+                "name": "latent_upscale_model",
+                "shape": 7,
+                "type": "LATENT_UPSCALE_MODEL",
+                "link": null
+              },
+              {
+                "localized_name": "vae",
+                "name": "vae",
+                "shape": 7,
+                "type": "VAE",
+                "link": 196
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "MODEL",
+                "name": "MODEL",
+                "type": "MODEL",
+                "links": [
+                  256
+                ]
+              }
+            ],
+            "properties": {
+              "cnr_id": "comfyui-kjnodes",
+              "ver": "1.3.4",
+              "Node name for S&R": "LTX2SamplingPreviewOverride",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              }
+            },
+            "widgets_values": [
+              24
+            ],
+            "color": "#222",
+            "bgcolor": "#000"
+          },
+          {
+            "id": 102,
+            "type": "Power Lora Loader (rgthree)",
+            "pos": [
+              2255.0773323012236,
+              4190.796594765089
+            ],
+            "size": [
+              340.519921875,
+              622
+            ],
+            "flags": {},
+            "order": 7,
+            "mode": 0,
+            "inputs": [
+              {
+                "dir": 3,
+                "name": "model",
+                "type": "MODEL",
+                "link": 256
+              },
+              {
+                "dir": 3,
+                "name": "clip",
+                "type": "CLIP",
+                "link": 253
+              }
+            ],
+            "outputs": [
+              {
+                "dir": 4,
+                "name": "MODEL",
+                "shape": 3,
+                "type": "MODEL",
+                "links": [
+                  257
+                ]
+              },
+              {
+                "dir": 4,
+                "name": "CLIP",
+                "shape": 3,
+                "type": "CLIP",
+                "links": [
+                  254
+                ]
+              }
+            ],
+            "properties": {
+              "cnr_id": "rgthree-comfy",
+              "ver": "738105af5fb14e96fbecaf406dc356e284797e8c",
+              "Show Strengths": "Single Strength",
+              "Match": "",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "input_ue_unconnectable": {},
+                "version": "7.8"
+              }
+            },
+            "widgets_values": [
+              {},
+              {
+                "type": "PowerLoraLoaderHeaderWidget"
+              },
+              {
+                "on": true,
+                "lora": "LTX2\\LTX2.3_reasoning_I2V_V3.safetensors",
+                "strength": 0.5,
+                "strengthTwo": null
+              },
+              {
+                "on": true,
+                "lora": "LTX2\\DR34ML4Y_LTXXX_PREVIEW_RC1.safetensors",
+                "strength": 0.5,
+                "strengthTwo": null
+              },
+              {},
+              ""
+            ]
+          },
+          {
+            "id": 80,
+            "type": "LoraLoaderModelOnly",
+            "pos": [
+              1215.5255907687376,
+              4164.482882371204
+            ],
+            "size": [
+              471.99154371923714,
+              101.34127262476522
+            ],
+            "flags": {},
+            "order": 8,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "model",
+                "name": "model",
+                "type": "MODEL",
+                "link": 257
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "MODEL",
+                "name": "MODEL",
+                "type": "MODEL",
+                "links": [
+                  199
+                ]
+              }
+            ],
+            "properties": {
+              "cnr_id": "comfy-core",
+              "ver": "0.3.75",
+              "Node name for S&R": "LoraLoaderModelOnly",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              }
+            },
+            "widgets_values": [
+              "ltx-2.3-22b-distilled-lora-dynamic_fro09_avg_rank_105_bf16.safetensors",
+              0.5
+            ],
+            "color": "#222",
+            "bgcolor": "#000"
+          }
+        ],
+        "groups": [],
+        "links": [
+          {
+            "id": 196,
+            "origin_id": 78,
+            "origin_slot": 0,
+            "target_id": 79,
+            "target_slot": 2,
+            "type": "VAE"
+          },
+          {
+            "id": 199,
+            "origin_id": 80,
+            "origin_slot": 0,
+            "target_id": -20,
+            "target_slot": 0,
+            "type": "MODEL"
+          },
+          {
+            "id": 58,
+            "origin_id": 4,
+            "origin_slot": 0,
+            "target_id": -20,
+            "target_slot": 2,
+            "type": "VAE"
+          },
+          {
+            "id": 16,
+            "origin_id": 3,
+            "origin_slot": 0,
+            "target_id": -20,
+            "target_slot": 3,
+            "type": "VAE"
+          },
+          {
+            "id": 253,
+            "origin_id": 84,
+            "origin_slot": 0,
+            "target_id": 102,
+            "target_slot": 1,
+            "type": "CLIP"
+          },
+          {
+            "id": 254,
+            "origin_id": 102,
+            "origin_slot": 1,
+            "target_id": -20,
+            "target_slot": 1,
+            "type": "CLIP"
+          },
+          {
+            "id": 255,
+            "origin_id": 77,
+            "origin_slot": 0,
+            "target_id": 79,
+            "target_slot": 0,
+            "type": "MODEL"
+          },
+          {
+            "id": 256,
+            "origin_id": 79,
+            "origin_slot": 0,
+            "target_id": 102,
+            "target_slot": 0,
+            "type": "MODEL"
+          },
+          {
+            "id": 257,
+            "origin_id": 102,
+            "origin_slot": 0,
+            "target_id": 80,
+            "target_slot": 0,
+            "type": "MODEL"
+          }
+        ],
+        "extra": {
+          "workflowRendererVersion": "LG",
+          "ue_links": [],
+          "links_added_by_ue": []
+        }
+      },
+      {
+        "id": "4b017e47-bf16-441b-ad03-edce978b3be3",
+        "version": 1,
+        "state": {
+          "lastGroupId": 6,
+          "lastNodeId": 104,
+          "lastLinkId": 258,
+          "lastRerouteId": 0
+        },
+        "revision": 0,
+        "config": {},
+        "name": "Stage #1",
+        "inputNode": {
+          "id": -10,
+          "bounding": [
+            2860,
+            4380,
+            128,
+            208
+          ]
+        },
+        "outputNode": {
+          "id": -20,
+          "bounding": [
+            4450,
+            4360,
+            128,
+            148
+          ]
+        },
+        "inputs": [
+          {
+            "id": "3c716dfb-4465-4519-8705-d5e7b88f1e35",
+            "name": "model",
+            "type": "MODEL",
+            "linkIds": [
+              115,
+              114
+            ],
+            "localized_name": "model",
+            "pos": [
+              2964,
+              4404
+            ]
+          },
+          {
+            "id": "dcb44156-9e87-4ef1-a7fd-6b8cb4de0beb",
+            "name": "audio_latent",
+            "type": "LATENT",
+            "linkIds": [
+              119
+            ],
+            "localized_name": "audio_latent",
+            "pos": [
+              2964,
+              4424
+            ]
+          },
+          {
+            "id": "0c7b8f30-c29e-4147-96e9-db7f6ca77e06",
+            "name": "vae",
+            "type": "VAE",
+            "linkIds": [
+              216
+            ],
+            "localized_name": "vae",
+            "pos": [
+              2964,
+              4444
+            ]
+          },
+          {
+            "id": "4286d415-0cbb-4310-94d2-0efdccfb429f",
+            "name": "latent",
+            "type": "LATENT",
+            "linkIds": [
+              118
+            ],
+            "localized_name": "latent",
+            "label": "video_latent",
+            "pos": [
+              2964,
+              4464
+            ]
+          },
+          {
+            "id": "24eebedb-6830-4afb-9337-bd06b1300d44",
+            "name": "guide_data",
+            "type": "GUIDE_DATA",
+            "linkIds": [
+              122
+            ],
+            "localized_name": "guide_data",
+            "pos": [
+              2964,
+              4484
+            ]
+          },
+          {
+            "id": "1dc63a0e-c430-406b-86a8-6eb45cbc7885",
+            "name": "positive",
+            "type": "CONDITIONING",
+            "linkIds": [
+              116,
+              117
+            ],
+            "localized_name": "positive",
+            "pos": [
+              2964,
+              4504
+            ]
+          },
+          {
+            "id": "02c2f048-017d-4fec-8440-19aa412bf8c0",
+            "name": "frame_rate",
+            "type": "FLOAT",
+            "linkIds": [
+              120
+            ],
+            "localized_name": "frame_rate",
+            "pos": [
+              2964,
+              4524
+            ]
+          },
+          {
+            "id": "f8636f26-27cb-4c55-972e-e5d1f6f39fff",
+            "name": "noise_seed",
+            "type": "INT",
+            "linkIds": [],
+            "pos": [
+              2964,
+              4544
+            ]
+          }
+        ],
+        "outputs": [
+          {
+            "id": "84f8d65a-1c3c-4fdc-8cab-7abaf67c1875",
+            "name": "positive",
+            "type": "CONDITIONING",
+            "linkIds": [
+              54,
+              54
+            ],
+            "localized_name": "positive",
+            "pos": [
+              4474,
+              4384
+            ]
+          },
+          {
+            "id": "6275837a-94b0-4318-bbce-15969c26e42b",
+            "name": "negative",
+            "type": "CONDITIONING",
+            "linkIds": [
+              55,
+              55
+            ],
+            "localized_name": "negative",
+            "pos": [
+              4474,
+              4404
+            ]
+          },
+          {
+            "id": "4c1b1c7e-3c92-4c13-8495-539df653574e",
+            "name": "NOISE",
+            "type": "NOISE",
+            "linkIds": [
+              157
+            ],
+            "localized_name": "NOISE",
+            "pos": [
+              4474,
+              4424
+            ]
+          },
+          {
+            "id": "f0f1c347-9ebf-496e-aea8-ca0a0ff7601e",
+            "name": "video_latent",
+            "type": "LATENT",
+            "linkIds": [
+              142
+            ],
+            "localized_name": "video_latent",
+            "pos": [
+              4474,
+              4444
+            ]
+          },
+          {
+            "id": "bf7e617a-cf3a-4ef6-a485-d3ab3e84742a",
+            "name": "audio_latent",
+            "type": "LATENT",
+            "linkIds": [
+              143
+            ],
+            "localized_name": "audio_latent",
+            "pos": [
+              4474,
+              4464
+            ]
+          }
+        ],
+        "widgets": [],
+        "nodes": [
+          {
+            "id": 11,
+            "type": "BasicScheduler",
+            "pos": [
+              3740,
+              4620
+            ],
+            "size": [
+              210,
+              110
+            ],
+            "flags": {},
+            "order": 7,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "model",
+                "name": "model",
+                "type": "MODEL",
+                "link": 115
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "SIGMAS",
+                "name": "SIGMAS",
+                "type": "SIGMAS",
+                "links": [
+                  52
+                ]
+              }
+            ],
+            "properties": {
+              "cnr_id": "comfy-core",
+              "ver": "0.16.4",
+              "Node name for S&R": "BasicScheduler",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              }
+            },
+            "widgets_values": [
+              "linear_quadratic",
+              8,
+              1
+            ],
+            "color": "#222",
+            "bgcolor": "#000"
+          },
+          {
+            "id": 10,
+            "type": "SamplerCustomAdvanced",
+            "pos": [
+              3960,
+              4390
+            ],
+            "size": [
+              220,
+              428.2932551319648
+            ],
+            "flags": {},
+            "order": 6,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "noise",
+                "name": "noise",
+                "type": "NOISE",
+                "link": 51
+              },
+              {
+                "localized_name": "guider",
+                "name": "guider",
+                "type": "GUIDER",
+                "link": 12
+              },
+              {
+                "localized_name": "sampler",
+                "name": "sampler",
+                "type": "SAMPLER",
+                "link": 53
+              },
+              {
+                "localized_name": "sigmas",
+                "name": "sigmas",
+                "type": "SIGMAS",
+                "link": 52
+              },
+              {
+                "localized_name": "latent_image",
+                "name": "latent_image",
+                "type": "LATENT",
+                "link": 14
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "output",
+                "name": "output",
+                "type": "LATENT",
+                "links": [
+                  156
+                ]
+              },
+              {
+                "localized_name": "denoised_output",
+                "name": "denoised_output",
+                "type": "LATENT",
+                "links": []
+              }
+            ],
+            "properties": {
+              "cnr_id": "comfy-core",
+              "ver": "0.3.60",
+              "Node name for S&R": "SamplerCustomAdvanced",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              }
+            },
+            "widgets_values": [],
+            "color": "#222",
+            "bgcolor": "#000"
+          },
+          {
+            "id": 29,
+            "type": "KSamplerSelect",
+            "pos": [
+              3740,
+              4520
+            ],
+            "size": [
+              210,
+              60
+            ],
+            "flags": {},
+            "order": 0,
+            "mode": 0,
+            "inputs": [],
+            "outputs": [
+              {
+                "localized_name": "SAMPLER",
+                "name": "SAMPLER",
+                "type": "SAMPLER",
+                "links": [
+                  53
+                ]
+              }
+            ],
+            "properties": {
+              "cnr_id": "comfy-core",
+              "ver": "0.3.56",
+              "Node name for S&R": "KSamplerSelect",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              }
+            },
+            "widgets_values": [
+              "euler"
+            ],
+            "color": "#222",
+            "bgcolor": "#000"
+          },
+          {
+            "id": 7,
+            "type": "LTXVConcatAVLatent",
+            "pos": [
+              3520,
+              4530
+            ],
+            "size": [
+              210,
+              50
+            ],
+            "flags": {},
+            "order": 3,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "video_latent",
+                "name": "video_latent",
+                "type": "LATENT",
+                "link": 108
+              },
+              {
+                "localized_name": "audio_latent",
+                "name": "audio_latent",
+                "type": "LATENT",
+                "link": 119
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "latent",
+                "name": "latent",
+                "type": "LATENT",
+                "links": [
+                  14
+                ]
+              }
+            ],
+            "properties": {
+              "cnr_id": "comfy-core",
+              "ver": "0.16.0",
+              "Node name for S&R": "LTXVConcatAVLatent",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              }
+            },
+            "widgets_values": [],
+            "color": "#222",
+            "bgcolor": "#000"
+          },
+          {
+            "id": 8,
+            "type": "LTXDirectorGuide",
+            "pos": [
+              3290,
+              4400
+            ],
+            "size": [
+              210,
+              180
+            ],
+            "flags": {},
+            "order": 4,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "positive",
+                "name": "positive",
+                "type": "CONDITIONING",
+                "link": 6
+              },
+              {
+                "localized_name": "negative",
+                "name": "negative",
+                "type": "CONDITIONING",
+                "link": 7
+              },
+              {
+                "localized_name": "vae",
+                "name": "vae",
+                "type": "VAE",
+                "link": 216
+              },
+              {
+                "localized_name": "latent",
+                "name": "latent",
+                "type": "LATENT",
+                "link": 118
+              },
+              {
+                "localized_name": "guide_data",
+                "name": "guide_data",
+                "type": "GUIDE_DATA",
+                "link": 122
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "positive",
+                "name": "positive",
+                "type": "CONDITIONING",
+                "links": [
+                  10,
+                  54
+                ]
+              },
+              {
+                "localized_name": "negative",
+                "name": "negative",
+                "type": "CONDITIONING",
+                "links": [
+                  11,
+                  55
+                ]
+              },
+              {
+                "localized_name": "latent",
+                "name": "latent",
+                "type": "LATENT",
+                "links": [
+                  108
+                ]
+              }
+            ],
+            "properties": {
+              "aux_id": "kijai/ComfyUI-PromptRelay",
+              "ver": "5cae3c00186ff2eb79771070f05a2c4e02f329bb",
+              "Node name for S&R": "LTXDirectorGuide",
+              "cnr_id": "whatdreamscost-comfyui",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              }
+            },
+            "widgets_values": [
+              0.5,
+              "bicubic"
+            ],
+            "color": "#222",
+            "bgcolor": "#000"
+          },
+          {
+            "id": 9,
+            "type": "CFGGuider",
+            "pos": [
+              3520,
+              4390
+            ],
+            "size": [
+              210,
+              100
+            ],
+            "flags": {},
+            "order": 5,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "model",
+                "name": "model",
+                "type": "MODEL",
+                "link": 114
+              },
+              {
+                "localized_name": "positive",
+                "name": "positive",
+                "type": "CONDITIONING",
+                "link": 10
+              },
+              {
+                "localized_name": "negative",
+                "name": "negative",
+                "type": "CONDITIONING",
+                "link": 11
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "GUIDER",
+                "name": "GUIDER",
+                "type": "GUIDER",
+                "links": [
+                  12
+                ]
+              }
+            ],
+            "properties": {
+              "cnr_id": "comfy-core",
+              "ver": "0.3.64",
+              "Node name for S&R": "CFGGuider",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              }
+            },
+            "widgets_values": [
+              1
+            ],
+            "color": "#222",
+            "bgcolor": "#000"
+          },
+          {
+            "id": 5,
+            "type": "LTXVConditioning",
+            "pos": [
+              3040,
+              4400
+            ],
+            "size": [
+              240,
+              80
+            ],
+            "flags": {},
+            "order": 2,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "positive",
+                "name": "positive",
+                "type": "CONDITIONING",
+                "link": 116
+              },
+              {
+                "localized_name": "negative",
+                "name": "negative",
+                "type": "CONDITIONING",
+                "link": 50
+              },
+              {
+                "localized_name": "frame_rate",
+                "name": "frame_rate",
+                "type": "FLOAT",
+                "widget": {
+                  "name": "frame_rate"
+                },
+                "link": 120
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "positive",
+                "name": "positive",
+                "type": "CONDITIONING",
+                "links": [
+                  6
+                ]
+              },
+              {
+                "localized_name": "negative",
+                "name": "negative",
+                "type": "CONDITIONING",
+                "links": [
+                  7
+                ]
+              }
+            ],
+            "properties": {
+              "cnr_id": "comfy-core",
+              "ver": "0.3.56",
+              "Node name for S&R": "LTXVConditioning",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              }
+            },
+            "widgets_values": [
+              24
+            ],
+            "color": "#222",
+            "bgcolor": "#000"
+          },
+          {
+            "id": 26,
+            "type": "ConditioningZeroOut",
+            "pos": [
+              3040,
+              4530
+            ],
+            "size": [
+              240,
+              30
+            ],
+            "flags": {},
+            "order": 9,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "conditioning",
+                "name": "conditioning",
+                "type": "CONDITIONING",
+                "link": 117
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "CONDITIONING",
+                "name": "CONDITIONING",
+                "type": "CONDITIONING",
+                "links": [
+                  50
+                ]
+              }
+            ],
+            "properties": {
+              "cnr_id": "comfy-core",
+              "ver": "0.19.3",
+              "Node name for S&R": "ConditioningZeroOut",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              }
+            },
+            "widgets_values": [],
+            "color": "#222",
+            "bgcolor": "#000"
+          },
+          {
+            "id": 13,
+            "type": "LTXVSeparateAVLatent",
+            "pos": [
+              4190,
+              4390
+            ],
+            "size": [
+              200,
+              50
+            ],
+            "flags": {},
+            "order": 8,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "av_latent",
+                "name": "av_latent",
+                "type": "LATENT",
+                "link": 156
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "video_latent",
+                "name": "video_latent",
+                "type": "LATENT",
+                "links": [
+                  142
+                ]
+              },
+              {
+                "localized_name": "audio_latent",
+                "name": "audio_latent",
+                "type": "LATENT",
+                "links": [
+                  143
+                ]
+              }
+            ],
+            "properties": {
+              "cnr_id": "comfy-core",
+              "ver": "0.16.0",
+              "Node name for S&R": "LTXVSeparateAVLatent",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              }
+            },
+            "widgets_values": [],
+            "color": "#222",
+            "bgcolor": "#000"
+          },
+          {
+            "id": 28,
+            "type": "RandomNoise",
+            "pos": [
+              3431.7423547807693,
+              4693.424337193137
+            ],
+            "size": [
+              210,
+              90
+            ],
+            "flags": {},
+            "order": 1,
+            "mode": 0,
+            "inputs": [
+              {
+                "label": "noise_seed",
+                "localized_name": "noise_seed",
+                "name": "noise_seed",
+                "type": "INT",
+                "widget": {
+                  "name": "noise_seed"
+                },
+                "link": null
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "NOISE",
+                "name": "NOISE",
+                "type": "NOISE",
+                "links": [
+                  51,
+                  157
+                ]
+              }
+            ],
+            "properties": {
+              "cnr_id": "comfy-core",
+              "ver": "0.19.3",
+              "Node name for S&R": "RandomNoise",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              }
+            },
+            "widgets_values": [
+              243141763309034,
+              "randomize"
+            ],
+            "color": "#222",
+            "bgcolor": "#000"
+          }
+        ],
+        "groups": [],
+        "links": [
+          {
+            "id": 51,
+            "origin_id": 28,
+            "origin_slot": 0,
+            "target_id": 10,
+            "target_slot": 0,
+            "type": "NOISE"
+          },
+          {
+            "id": 12,
+            "origin_id": 9,
+            "origin_slot": 0,
+            "target_id": 10,
+            "target_slot": 1,
+            "type": "GUIDER"
+          },
+          {
+            "id": 53,
+            "origin_id": 29,
+            "origin_slot": 0,
+            "target_id": 10,
+            "target_slot": 2,
+            "type": "SAMPLER"
+          },
+          {
+            "id": 52,
+            "origin_id": 11,
+            "origin_slot": 0,
+            "target_id": 10,
+            "target_slot": 3,
+            "type": "SIGMAS"
+          },
+          {
+            "id": 14,
+            "origin_id": 7,
+            "origin_slot": 0,
+            "target_id": 10,
+            "target_slot": 4,
+            "type": "LATENT"
+          },
+          {
+            "id": 108,
+            "origin_id": 8,
+            "origin_slot": 2,
+            "target_id": 7,
+            "target_slot": 0,
+            "type": "LATENT"
+          },
+          {
+            "id": 6,
+            "origin_id": 5,
+            "origin_slot": 0,
+            "target_id": 8,
+            "target_slot": 0,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 7,
+            "origin_id": 5,
+            "origin_slot": 1,
+            "target_id": 8,
+            "target_slot": 1,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 10,
+            "origin_id": 8,
+            "origin_slot": 0,
+            "target_id": 9,
+            "target_slot": 1,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 11,
+            "origin_id": 8,
+            "origin_slot": 1,
+            "target_id": 9,
+            "target_slot": 2,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 50,
+            "origin_id": 26,
+            "origin_slot": 0,
+            "target_id": 5,
+            "target_slot": 1,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 156,
+            "origin_id": 10,
+            "origin_slot": 0,
+            "target_id": 13,
+            "target_slot": 0,
+            "type": "LATENT"
+          },
+          {
+            "id": 115,
+            "origin_id": -10,
+            "origin_slot": 0,
+            "target_id": 11,
+            "target_slot": 0,
+            "type": "MODEL"
+          },
+          {
+            "id": 114,
+            "origin_id": -10,
+            "origin_slot": 0,
+            "target_id": 9,
+            "target_slot": 0,
+            "type": "MODEL"
+          },
+          {
+            "id": 119,
+            "origin_id": -10,
+            "origin_slot": 1,
+            "target_id": 7,
+            "target_slot": 1,
+            "type": "LATENT"
+          },
+          {
+            "id": 216,
+            "origin_id": -10,
+            "origin_slot": 2,
+            "target_id": 8,
+            "target_slot": 2,
+            "type": "VAE"
+          },
+          {
+            "id": 118,
+            "origin_id": -10,
+            "origin_slot": 3,
+            "target_id": 8,
+            "target_slot": 3,
+            "type": "LATENT"
+          },
+          {
+            "id": 122,
+            "origin_id": -10,
+            "origin_slot": 4,
+            "target_id": 8,
+            "target_slot": 4,
+            "type": "GUIDE_DATA"
+          },
+          {
+            "id": 116,
+            "origin_id": -10,
+            "origin_slot": 5,
+            "target_id": 5,
+            "target_slot": 0,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 117,
+            "origin_id": -10,
+            "origin_slot": 5,
+            "target_id": 26,
+            "target_slot": 0,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 120,
+            "origin_id": -10,
+            "origin_slot": 6,
+            "target_id": 5,
+            "target_slot": 2,
+            "type": "FLOAT"
+          },
+          {
+            "id": 54,
+            "origin_id": 8,
+            "origin_slot": 0,
+            "target_id": -20,
+            "target_slot": 0,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 55,
+            "origin_id": 8,
+            "origin_slot": 1,
+            "target_id": -20,
+            "target_slot": 1,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 157,
+            "origin_id": 28,
+            "origin_slot": 0,
+            "target_id": -20,
+            "target_slot": 2,
+            "type": "NOISE"
+          },
+          {
+            "id": 142,
+            "origin_id": 13,
+            "origin_slot": 0,
+            "target_id": -20,
+            "target_slot": 3,
+            "type": "LATENT"
+          },
+          {
+            "id": 143,
+            "origin_id": 13,
+            "origin_slot": 1,
+            "target_id": -20,
+            "target_slot": 4,
+            "type": "LATENT"
+          }
+        ],
+        "extra": {
+          "workflowRendererVersion": "LG",
+          "ue_links": [],
+          "links_added_by_ue": []
+        }
+      },
+      {
+        "id": "7cf6430b-4784-4af1-8cde-9268e9465c62",
+        "version": 1,
+        "state": {
+          "lastGroupId": 6,
+          "lastNodeId": 104,
+          "lastLinkId": 258,
+          "lastRerouteId": 0
+        },
+        "revision": 0,
+        "config": {},
+        "name": "Stage #2",
+        "inputNode": {
+          "id": -10,
+          "bounding": [
+            2870,
+            3980,
+            128,
+            208
+          ]
+        },
+        "outputNode": {
+          "id": -20,
+          "bounding": [
+            4430,
+            3900,
+            128,
+            88
+          ]
+        },
+        "inputs": [
+          {
+            "id": "da8ac1d4-baaa-49af-a44f-51de815b8adc",
+            "name": "positive",
+            "type": "CONDITIONING",
+            "linkIds": [
+              228,
+              227
+            ],
+            "localized_name": "positive",
+            "pos": [
+              2974,
+              4004
+            ]
+          },
+          {
+            "id": "2a2ae901-93e9-4551-97e5-bf33db9a7761",
+            "name": "negative",
+            "type": "CONDITIONING",
+            "linkIds": [
+              230,
+              229
+            ],
+            "localized_name": "negative",
+            "pos": [
+              2974,
+              4024
+            ]
+          },
+          {
+            "id": "f6f33172-a93d-4505-a3c8-4e4e61488f94",
+            "name": "latent",
+            "type": "LATENT",
+            "linkIds": [
+              232
+            ],
+            "localized_name": "latent",
+            "label": "video_latent",
+            "pos": [
+              2974,
+              4044
+            ]
+          },
+          {
+            "id": "9d67923c-e4e8-4eb5-a91b-b37dbfb5882f",
+            "name": "vae",
+            "type": "VAE",
+            "linkIds": [
+              219,
+              218
+            ],
+            "localized_name": "vae",
+            "label": "video_vae",
+            "pos": [
+              2974,
+              4064
+            ]
+          },
+          {
+            "id": "c5f8e7de-87ec-4509-892c-8cc4e1f14575",
+            "name": "guide_data",
+            "type": "GUIDE_DATA",
+            "linkIds": [
+              151
+            ],
+            "localized_name": "guide_data",
+            "pos": [
+              2974,
+              4084
+            ]
+          },
+          {
+            "id": "c9c467d0-0426-4288-a31e-b41be1891bdc",
+            "name": "model",
+            "type": "MODEL",
+            "linkIds": [
+              158,
+              159
+            ],
+            "localized_name": "model",
+            "pos": [
+              2974,
+              4104
+            ]
+          },
+          {
+            "id": "1c4bd34a-4e48-455a-bd66-323524e5c2d8",
+            "name": "noise",
+            "type": "NOISE",
+            "linkIds": [
+              231
+            ],
+            "localized_name": "noise",
+            "pos": [
+              2974,
+              4124
+            ]
+          },
+          {
+            "id": "ef0cc4fb-4a9f-404b-a62c-92e04fd74171",
+            "name": "audio_latent",
+            "type": "LATENT",
+            "linkIds": [
+              233
+            ],
+            "localized_name": "audio_latent",
+            "pos": [
+              2974,
+              4144
+            ]
+          }
+        ],
+        "outputs": [
+          {
+            "id": "402aed7a-321d-48a8-a407-34f05a5ab1e2",
+            "name": "audio_latent",
+            "type": "LATENT",
+            "linkIds": [
+              202
+            ],
+            "localized_name": "audio_latent",
+            "pos": [
+              4454,
+              3924
+            ]
+          },
+          {
+            "id": "8fe53957-38d9-459e-a590-3ad4d96d3616",
+            "name": "latent",
+            "type": "LATENT",
+            "linkIds": [
+              208
+            ],
+            "localized_name": "latent",
+            "pos": [
+              4454,
+              3944
+            ]
+          }
+        ],
+        "widgets": [],
+        "nodes": [
+          {
+            "id": 55,
+            "type": "LTXVCropGuides",
+            "pos": [
+              3050,
+              3930
+            ],
+            "size": [
+              250,
+              70
+            ],
+            "flags": {},
+            "order": 9,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "positive",
+                "name": "positive",
+                "type": "CONDITIONING",
+                "link": 228
+              },
+              {
+                "localized_name": "negative",
+                "name": "negative",
+                "type": "CONDITIONING",
+                "link": 230
+              },
+              {
+                "localized_name": "latent",
+                "name": "latent",
+                "type": "LATENT",
+                "link": 232
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "positive",
+                "name": "positive",
+                "type": "CONDITIONING",
+                "links": [
+                  146
+                ]
+              },
+              {
+                "localized_name": "negative",
+                "name": "negative",
+                "type": "CONDITIONING",
+                "links": [
+                  147
+                ]
+              },
+              {
+                "localized_name": "latent",
+                "name": "latent",
+                "type": "LATENT",
+                "links": [
+                  135
+                ]
+              }
+            ],
+            "properties": {
+              "cnr_id": "comfy-core",
+              "ver": "0.16.4",
+              "Node name for S&R": "LTXVCropGuides",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              }
+            },
+            "widgets_values": [],
+            "color": "#222",
+            "bgcolor": "#000"
+          },
+          {
+            "id": 58,
+            "type": "LTXDirectorGuide",
+            "pos": [
+              3310,
+              3930
+            ],
+            "size": [
+              210,
+              190
+            ],
+            "flags": {},
+            "order": 10,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "positive",
+                "name": "positive",
+                "type": "CONDITIONING",
+                "link": 146
+              },
+              {
+                "localized_name": "negative",
+                "name": "negative",
+                "type": "CONDITIONING",
+                "link": 147
+              },
+              {
+                "localized_name": "vae",
+                "name": "vae",
+                "type": "VAE",
+                "link": 219
+              },
+              {
+                "localized_name": "latent",
+                "name": "latent",
+                "type": "LATENT",
+                "link": 150
+              },
+              {
+                "localized_name": "guide_data",
+                "name": "guide_data",
+                "type": "GUIDE_DATA",
+                "link": 151
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "positive",
+                "name": "positive",
+                "type": "CONDITIONING",
+                "links": [
+                  152
+                ]
+              },
+              {
+                "localized_name": "negative",
+                "name": "negative",
+                "type": "CONDITIONING",
+                "links": [
+                  153
+                ]
+              },
+              {
+                "localized_name": "latent",
+                "name": "latent",
+                "type": "LATENT",
+                "links": [
+                  154
+                ]
+              }
+            ],
+            "properties": {
+              "aux_id": "kijai/ComfyUI-PromptRelay",
+              "ver": "5cae3c00186ff2eb79771070f05a2c4e02f329bb",
+              "Node name for S&R": "LTXDirectorGuide",
+              "cnr_id": "whatdreamscost-comfyui",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              }
+            },
+            "widgets_values": [
+              1,
+              "bicubic"
+            ],
+            "color": "#222",
+            "bgcolor": "#000"
+          },
+          {
+            "id": 49,
+            "type": "CFGGuider",
+            "pos": [
+              3540,
+              3920
+            ],
+            "size": [
+              210,
+              100
+            ],
+            "flags": {},
+            "order": 5,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "model",
+                "name": "model",
+                "type": "MODEL",
+                "link": 158
+              },
+              {
+                "localized_name": "positive",
+                "name": "positive",
+                "type": "CONDITIONING",
+                "link": 152
+              },
+              {
+                "localized_name": "negative",
+                "name": "negative",
+                "type": "CONDITIONING",
+                "link": 153
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "GUIDER",
+                "name": "GUIDER",
+                "type": "GUIDER",
+                "links": [
+                  124
+                ]
+              }
+            ],
+            "properties": {
+              "cnr_id": "comfy-core",
+              "ver": "0.3.64",
+              "Node name for S&R": "CFGGuider",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              }
+            },
+            "widgets_values": [
+              1
+            ],
+            "color": "#222",
+            "bgcolor": "#000"
+          },
+          {
+            "id": 53,
+            "type": "KSamplerSelect",
+            "pos": [
+              3540,
+              4060
+            ],
+            "size": [
+              210,
+              60
+            ],
+            "flags": {},
+            "order": 0,
+            "mode": 0,
+            "inputs": [],
+            "outputs": [
+              {
+                "localized_name": "SAMPLER",
+                "name": "SAMPLER",
+                "type": "SAMPLER",
+                "links": [
+                  125
+                ]
+              }
+            ],
+            "properties": {
+              "cnr_id": "comfy-core",
+              "ver": "0.3.56",
+              "Node name for S&R": "KSamplerSelect",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              }
+            },
+            "widgets_values": [
+              "euler"
+            ],
+            "color": "#222",
+            "bgcolor": "#000"
+          },
+          {
+            "id": 47,
+            "type": "SamplerCustomAdvanced",
+            "pos": [
+              3760,
+              3920
+            ],
+            "size": [
+              230,
+              443.30791788856305
+            ],
+            "flags": {},
+            "order": 3,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "noise",
+                "name": "noise",
+                "type": "NOISE",
+                "link": 231
+              },
+              {
+                "localized_name": "guider",
+                "name": "guider",
+                "type": "GUIDER",
+                "link": 124
+              },
+              {
+                "localized_name": "sampler",
+                "name": "sampler",
+                "type": "SAMPLER",
+                "link": 125
+              },
+              {
+                "localized_name": "sigmas",
+                "name": "sigmas",
+                "type": "SIGMAS",
+                "link": 126
+              },
+              {
+                "localized_name": "latent_image",
+                "name": "latent_image",
+                "type": "LATENT",
+                "link": 127
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "output",
+                "name": "output",
+                "type": "LATENT",
+                "links": [
+                  180
+                ]
+              },
+              {
+                "localized_name": "denoised_output",
+                "name": "denoised_output",
+                "type": "LATENT",
+                "links": []
+              }
+            ],
+            "properties": {
+              "cnr_id": "comfy-core",
+              "ver": "0.3.60",
+              "Node name for S&R": "SamplerCustomAdvanced",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              }
+            },
+            "widgets_values": [],
+            "color": "#222",
+            "bgcolor": "#000"
+          },
+          {
+            "id": 57,
+            "type": "LatentUpscaleModelLoader",
+            "pos": [
+              3050,
+              4040
+            ],
+            "size": [
+              250,
+              70
+            ],
+            "flags": {},
+            "order": 1,
+            "mode": 0,
+            "inputs": [],
+            "outputs": [
+              {
+                "localized_name": "LATENT_UPSCALE_MODEL",
+                "name": "LATENT_UPSCALE_MODEL",
+                "type": "LATENT_UPSCALE_MODEL",
+                "links": [
+                  144
+                ]
+              }
+            ],
+            "properties": {
+              "cnr_id": "comfy-core",
+              "ver": "0.16.4",
+              "Node name for S&R": "LatentUpscaleModelLoader",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              }
+            },
+            "widgets_values": [
+              "ltx-2.3-spatial-upscaler-x2-1.1.safetensors"
+            ],
+            "color": "#222",
+            "bgcolor": "#000"
+          },
+          {
+            "id": 48,
+            "type": "LTXVSeparateAVLatent",
+            "pos": [
+              4000,
+              3920
+            ],
+            "size": [
+              200,
+              50
+            ],
+            "flags": {},
+            "order": 4,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "av_latent",
+                "name": "av_latent",
+                "type": "LATENT",
+                "link": 180
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "video_latent",
+                "name": "video_latent",
+                "type": "LATENT",
+                "links": [
+                  136
+                ]
+              },
+              {
+                "localized_name": "audio_latent",
+                "name": "audio_latent",
+                "type": "LATENT",
+                "links": [
+                  202
+                ]
+              }
+            ],
+            "properties": {
+              "cnr_id": "comfy-core",
+              "ver": "0.5.1",
+              "Node name for S&R": "LTXVSeparateAVLatent",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              }
+            },
+            "widgets_values": [],
+            "color": "#222",
+            "bgcolor": "#000"
+          },
+          {
+            "id": 52,
+            "type": "LTXVLatentUpsampler",
+            "pos": [
+              3050,
+              4150
+            ],
+            "size": [
+              250,
+              70
+            ],
+            "flags": {},
+            "order": 7,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "samples",
+                "name": "samples",
+                "type": "LATENT",
+                "link": 135
+              },
+              {
+                "localized_name": "upscale_model",
+                "name": "upscale_model",
+                "type": "LATENT_UPSCALE_MODEL",
+                "link": 144
+              },
+              {
+                "localized_name": "vae",
+                "name": "vae",
+                "type": "VAE",
+                "link": 218
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "LATENT",
+                "name": "LATENT",
+                "type": "LATENT",
+                "links": [
+                  150
+                ]
+              }
+            ],
+            "properties": {
+              "cnr_id": "comfy-core",
+              "ver": "0.14.1",
+              "Node name for S&R": "LTXVLatentUpsampler",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              }
+            },
+            "widgets_values": [],
+            "color": "#222",
+            "bgcolor": "#000"
+          },
+          {
+            "id": 54,
+            "type": "BasicScheduler",
+            "pos": [
+              3540,
+              4160
+            ],
+            "size": [
+              210,
+              110
+            ],
+            "flags": {},
+            "order": 8,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "model",
+                "name": "model",
+                "type": "MODEL",
+                "link": 159
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "SIGMAS",
+                "name": "SIGMAS",
+                "type": "SIGMAS",
+                "links": [
+                  126
+                ]
+              }
+            ],
+            "properties": {
+              "cnr_id": "comfy-core",
+              "ver": "0.16.4",
+              "Node name for S&R": "BasicScheduler",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              }
+            },
+            "widgets_values": [
+              "linear_quadratic",
+              4,
+              0.42
+            ],
+            "color": "#222",
+            "bgcolor": "#000"
+          },
+          {
+            "id": 50,
+            "type": "LTXVConcatAVLatent",
+            "pos": [
+              3310,
+              4160
+            ],
+            "size": [
+              210,
+              60
+            ],
+            "flags": {},
+            "order": 6,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "video_latent",
+                "name": "video_latent",
+                "type": "LATENT",
+                "link": 154
+              },
+              {
+                "localized_name": "audio_latent",
+                "name": "audio_latent",
+                "type": "LATENT",
+                "link": 233
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "latent",
+                "name": "latent",
+                "type": "LATENT",
+                "links": [
+                  127
+                ]
+              }
+            ],
+            "properties": {
+              "cnr_id": "comfy-core",
+              "ver": "0.7.0",
+              "Node name for S&R": "LTXVConcatAVLatent",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              }
+            },
+            "widgets_values": [],
+            "color": "#222",
+            "bgcolor": "#000"
+          },
+          {
+            "id": 14,
+            "type": "LTXVCropGuides",
+            "pos": [
+              4210,
+              3920
+            ],
+            "size": [
+              180,
+              70
+            ],
+            "flags": {},
+            "order": 2,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "positive",
+                "name": "positive",
+                "type": "CONDITIONING",
+                "link": 227
+              },
+              {
+                "localized_name": "negative",
+                "name": "negative",
+                "type": "CONDITIONING",
+                "link": 229
+              },
+              {
+                "localized_name": "latent",
+                "name": "latent",
+                "type": "LATENT",
+                "link": 136
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "positive",
+                "name": "positive",
+                "type": "CONDITIONING",
+                "links": null
+              },
+              {
+                "localized_name": "negative",
+                "name": "negative",
+                "type": "CONDITIONING",
+                "links": null
+              },
+              {
+                "localized_name": "latent",
+                "name": "latent",
+                "type": "LATENT",
+                "links": [
+                  208
+                ]
+              }
+            ],
+            "properties": {
+              "cnr_id": "comfy-core",
+              "ver": "0.19.3",
+              "Node name for S&R": "LTXVCropGuides",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              }
+            },
+            "widgets_values": [],
+            "color": "#222",
+            "bgcolor": "#000"
+          }
+        ],
+        "groups": [],
+        "links": [
+          {
+            "id": 146,
+            "origin_id": 55,
+            "origin_slot": 0,
+            "target_id": 58,
+            "target_slot": 0,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 147,
+            "origin_id": 55,
+            "origin_slot": 1,
+            "target_id": 58,
+            "target_slot": 1,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 150,
+            "origin_id": 52,
+            "origin_slot": 0,
+            "target_id": 58,
+            "target_slot": 3,
+            "type": "LATENT"
+          },
+          {
+            "id": 152,
+            "origin_id": 58,
+            "origin_slot": 0,
+            "target_id": 49,
+            "target_slot": 1,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 153,
+            "origin_id": 58,
+            "origin_slot": 1,
+            "target_id": 49,
+            "target_slot": 2,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 124,
+            "origin_id": 49,
+            "origin_slot": 0,
+            "target_id": 47,
+            "target_slot": 1,
+            "type": "GUIDER"
+          },
+          {
+            "id": 125,
+            "origin_id": 53,
+            "origin_slot": 0,
+            "target_id": 47,
+            "target_slot": 2,
+            "type": "SAMPLER"
+          },
+          {
+            "id": 126,
+            "origin_id": 54,
+            "origin_slot": 0,
+            "target_id": 47,
+            "target_slot": 3,
+            "type": "SIGMAS"
+          },
+          {
+            "id": 127,
+            "origin_id": 50,
+            "origin_slot": 0,
+            "target_id": 47,
+            "target_slot": 4,
+            "type": "LATENT"
+          },
+          {
+            "id": 180,
+            "origin_id": 47,
+            "origin_slot": 0,
+            "target_id": 48,
+            "target_slot": 0,
+            "type": "LATENT"
+          },
+          {
+            "id": 135,
+            "origin_id": 55,
+            "origin_slot": 2,
+            "target_id": 52,
+            "target_slot": 0,
+            "type": "LATENT"
+          },
+          {
+            "id": 144,
+            "origin_id": 57,
+            "origin_slot": 0,
+            "target_id": 52,
+            "target_slot": 1,
+            "type": "LATENT_UPSCALE_MODEL"
+          },
+          {
+            "id": 154,
+            "origin_id": 58,
+            "origin_slot": 2,
+            "target_id": 50,
+            "target_slot": 0,
+            "type": "LATENT"
+          },
+          {
+            "id": 136,
+            "origin_id": 48,
+            "origin_slot": 0,
+            "target_id": 14,
+            "target_slot": 2,
+            "type": "LATENT"
+          },
+          {
+            "id": 228,
+            "origin_id": -10,
+            "origin_slot": 0,
+            "target_id": 55,
+            "target_slot": 0,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 227,
+            "origin_id": -10,
+            "origin_slot": 0,
+            "target_id": 14,
+            "target_slot": 0,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 230,
+            "origin_id": -10,
+            "origin_slot": 1,
+            "target_id": 55,
+            "target_slot": 1,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 229,
+            "origin_id": -10,
+            "origin_slot": 1,
+            "target_id": 14,
+            "target_slot": 1,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 232,
+            "origin_id": -10,
+            "origin_slot": 2,
+            "target_id": 55,
+            "target_slot": 2,
+            "type": "LATENT"
+          },
+          {
+            "id": 219,
+            "origin_id": -10,
+            "origin_slot": 3,
+            "target_id": 58,
+            "target_slot": 2,
+            "type": "VAE"
+          },
+          {
+            "id": 218,
+            "origin_id": -10,
+            "origin_slot": 3,
+            "target_id": 52,
+            "target_slot": 2,
+            "type": "VAE"
+          },
+          {
+            "id": 151,
+            "origin_id": -10,
+            "origin_slot": 4,
+            "target_id": 58,
+            "target_slot": 4,
+            "type": "GUIDE_DATA"
+          },
+          {
+            "id": 158,
+            "origin_id": -10,
+            "origin_slot": 5,
+            "target_id": 49,
+            "target_slot": 0,
+            "type": "MODEL"
+          },
+          {
+            "id": 159,
+            "origin_id": -10,
+            "origin_slot": 5,
+            "target_id": 54,
+            "target_slot": 0,
+            "type": "MODEL"
+          },
+          {
+            "id": 231,
+            "origin_id": -10,
+            "origin_slot": 6,
+            "target_id": 47,
+            "target_slot": 0,
+            "type": "NOISE"
+          },
+          {
+            "id": 233,
+            "origin_id": -10,
+            "origin_slot": 7,
+            "target_id": 50,
+            "target_slot": 1,
+            "type": "LATENT"
+          },
+          {
+            "id": 202,
+            "origin_id": 48,
+            "origin_slot": 1,
+            "target_id": -20,
+            "target_slot": 0,
+            "type": "LATENT"
+          },
+          {
+            "id": 208,
+            "origin_id": 14,
+            "origin_slot": 2,
+            "target_id": -20,
+            "target_slot": 1,
+            "type": "LATENT"
+          }
+        ],
+        "extra": {
+          "workflowRendererVersion": "LG",
+          "ue_links": [],
+          "links_added_by_ue": []
+        }
+      },
+      {
+        "id": "739520a4-718f-490f-87d1-34ffbca98e3f",
+        "version": 1,
+        "state": {
+          "lastGroupId": 6,
+          "lastNodeId": 104,
+          "lastLinkId": 258,
+          "lastRerouteId": 0
+        },
+        "revision": 0,
+        "config": {},
+        "name": "Decode",
+        "inputNode": {
+          "id": -10,
+          "bounding": [
+            3330,
+            4105,
+            120,
+            140
+          ]
+        },
+        "outputNode": {
+          "id": -20,
+          "bounding": [
+            3780,
+            4145,
+            120,
+            60
+          ]
+        },
+        "inputs": [
+          {
+            "id": "35c40a03-3855-445e-a691-ae0ada359280",
+            "name": "samples",
+            "type": "LATENT",
+            "linkIds": [
+              242
+            ],
+            "localized_name": "samples",
+            "label": "audio_latent",
+            "pos": [
+              3430,
+              4125
+            ]
+          },
+          {
+            "id": "ddfb8ed1-1fd2-4086-ad94-d816dab3b6bb",
+            "name": "audio_vae",
+            "type": "VAE",
+            "linkIds": [
+              214
+            ],
+            "localized_name": "audio_vae",
+            "label": "audio_vae",
+            "pos": [
+              3430,
+              4145
+            ]
+          },
+          {
+            "id": "458157ba-efe8-4aa2-847e-be97d78a6873",
+            "name": "samples_1",
+            "type": "LATENT",
+            "linkIds": [
+              243
+            ],
+            "localized_name": "samples_1",
+            "label": "video_latent",
+            "pos": [
+              3430,
+              4165
+            ]
+          },
+          {
+            "id": "b02f1f71-c594-437f-8dda-4bb0f19c2e3e",
+            "name": "vae",
+            "type": "VAE",
+            "linkIds": [
+              217
+            ],
+            "localized_name": "vae",
+            "label": "video_vae",
+            "pos": [
+              3430,
+              4185
+            ]
+          },
+          {
+            "id": "83aa76da-c7d7-41b5-a3d6-4942595be90c",
+            "name": "fps",
+            "type": "FLOAT",
+            "linkIds": [
+              121
+            ],
+            "localized_name": "fps",
+            "pos": [
+              3430,
+              4205
+            ]
+          }
+        ],
+        "outputs": [
+          {
+            "id": "7d63e3c3-78d0-4613-9631-0fa830d1bf9a",
+            "name": "VIDEO",
+            "type": "VIDEO",
+            "linkIds": [
+              56
+            ],
+            "localized_name": "VIDEO",
+            "pos": [
+              3800,
+              4165
+            ]
+          }
+        ],
+        "widgets": [],
+        "nodes": [
+          {
+            "id": 16,
+            "type": "LTXVAudioVAEDecode",
+            "pos": [
+              3510,
+              4060
+            ],
+            "size": [
+              210,
+              50
+            ],
+            "flags": {},
+            "order": 1,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "samples",
+                "name": "samples",
+                "type": "LATENT",
+                "link": 242
+              },
+              {
+                "label": "Audio VAE",
+                "localized_name": "audio_vae",
+                "name": "audio_vae",
+                "type": "VAE",
+                "link": 214
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "Audio",
+                "name": "Audio",
+                "type": "AUDIO",
+                "links": [
+                  25
+                ]
+              }
+            ],
+            "properties": {
+              "cnr_id": "comfy-core",
+              "ver": "0.16.0",
+              "Node name for S&R": "LTXVAudioVAEDecode",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              }
+            },
+            "widgets_values": [],
+            "color": "#222",
+            "bgcolor": "#000"
+          },
+          {
+            "id": 15,
+            "type": "VAEDecode",
+            "pos": [
+              3510,
+              4150
+            ],
+            "size": [
+              210,
+              50
+            ],
+            "flags": {},
+            "order": 0,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "samples",
+                "name": "samples",
+                "type": "LATENT",
+                "link": 243
+              },
+              {
+                "localized_name": "vae",
+                "name": "vae",
+                "type": "VAE",
+                "link": 217
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "IMAGE",
+                "name": "IMAGE",
+                "type": "IMAGE",
+                "links": [
+                  24
+                ]
+              }
+            ],
+            "properties": {
+              "cnr_id": "comfy-core",
+              "ver": "0.9.1",
+              "Node name for S&R": "VAEDecode",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              }
+            },
+            "widgets_values": [],
+            "color": "#222",
+            "bgcolor": "#000"
+          },
+          {
+            "id": 17,
+            "type": "CreateVideo",
+            "pos": [
+              3510,
+              4240
+            ],
+            "size": [
+              210,
+              80
+            ],
+            "flags": {},
+            "order": 2,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "images",
+                "name": "images",
+                "type": "IMAGE",
+                "link": 24
+              },
+              {
+                "localized_name": "audio",
+                "name": "audio",
+                "shape": 7,
+                "type": "AUDIO",
+                "link": 25
+              },
+              {
+                "localized_name": "fps",
+                "name": "fps",
+                "type": "FLOAT",
+                "widget": {
+                  "name": "fps"
+                },
+                "link": 121
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "VIDEO",
+                "name": "VIDEO",
+                "type": "VIDEO",
+                "links": [
+                  56
+                ]
+              }
+            ],
+            "properties": {
+              "cnr_id": "comfy-core",
+              "ver": "0.19.3",
+              "Node name for S&R": "CreateVideo",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              }
+            },
+            "widgets_values": [
+              24
+            ],
+            "color": "#222",
+            "bgcolor": "#000"
+          }
+        ],
+        "groups": [],
+        "links": [
+          {
+            "id": 24,
+            "origin_id": 15,
+            "origin_slot": 0,
+            "target_id": 17,
+            "target_slot": 0,
+            "type": "IMAGE"
+          },
+          {
+            "id": 25,
+            "origin_id": 16,
+            "origin_slot": 0,
+            "target_id": 17,
+            "target_slot": 1,
+            "type": "AUDIO"
+          },
+          {
+            "id": 242,
+            "origin_id": -10,
+            "origin_slot": 0,
+            "target_id": 16,
+            "target_slot": 0,
+            "type": "LATENT"
+          },
+          {
+            "id": 214,
+            "origin_id": -10,
+            "origin_slot": 1,
+            "target_id": 16,
+            "target_slot": 1,
+            "type": "VAE"
+          },
+          {
+            "id": 243,
+            "origin_id": -10,
+            "origin_slot": 2,
+            "target_id": 15,
+            "target_slot": 0,
+            "type": "LATENT"
+          },
+          {
+            "id": 217,
+            "origin_id": -10,
+            "origin_slot": 3,
+            "target_id": 15,
+            "target_slot": 1,
+            "type": "VAE"
+          },
+          {
+            "id": 121,
+            "origin_id": -10,
+            "origin_slot": 4,
+            "target_id": 17,
+            "target_slot": 2,
+            "type": "FLOAT"
+          },
+          {
+            "id": 56,
+            "origin_id": 17,
+            "origin_slot": 0,
+            "target_id": -20,
+            "target_slot": 0,
+            "type": "VIDEO"
+          }
+        ],
+        "extra": {
+          "workflowRendererVersion": "LG",
+          "ue_links": [],
+          "links_added_by_ue": []
+        }
+      }
+    ]
+  },
+  "config": {},
+  "extra": {
+    "frontendVersion": "1.43.18",
+    "VHS_latentpreview": false,
+    "VHS_latentpreviewrate": 0,
+    "VHS_MetadataImage": true,
+    "VHS_KeepIntermediate": true,
+    "workflowRendererVersion": "LG",
+    "ue_links": [],
+    "links_added_by_ue": [],
+    "ds": {
+      "scale": 0.593315663706161,
+      "offset": [
+        -390.85785408136417,
+        -3933.2483114204406
+      ]
+    }
+  },
+  "version": 0.4
+}

--- a/js/ltx_director.js
+++ b/js/ltx_director.js
@@ -116,6 +116,43 @@ const STYLES = `
     width: 100%;
     flex-grow: 1; /* Automatically scales to fill node height */
     min-height: 40px;
+    gap: 4px;
+  }
+  .pr-hint-row {
+    display: flex;
+    align-items: center;
+    gap: 5px;
+    width: 100%;
+    flex-shrink: 0;
+  }
+  .pr-hint-label {
+    font-size: 10px;
+    font-weight: 600;
+    color: #888;
+    white-space: nowrap;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    flex-shrink: 0;
+  }
+  .pr-hint-input {
+    flex: 1;
+    background: #1a1a2e;
+    color: #b0b0ff;
+    border: 1px solid #3a3a6e;
+    border-radius: 4px;
+    padding: 3px 7px;
+    font-size: 11px;
+    outline: none;
+    box-sizing: border-box;
+    font-style: italic;
+  }
+  .pr-hint-input:focus {
+    border-color: #6060cc;
+    color: #d0d0ff;
+  }
+  .pr-hint-input::placeholder {
+    color: #5a5a8a;
+    font-style: italic;
   }
   .pr-prompt-area {
     width: 100%;
@@ -384,25 +421,28 @@ const STYLES = `
   }
   .pr-settings-menu {
     position: fixed;
-    background: #1e1e1e;
-    border: 1px solid #444;
+    background: #1e1e1e !important;
+    color: #e0e0e0 !important;
+    border: 1px solid #555 !important;
     border-radius: 6px;
     padding: 10px;
     display: flex;
     flex-direction: column;
     gap: 8px;
     z-index: 9999;
-    box-shadow: 0 4px 20px rgba(0,0,0,0.7);
-    min-width: 220px;
+    box-shadow: 0 4px 24px rgba(0,0,0,0.85);
+    min-width: 260px;
+    max-height: 85vh;
+    overflow-y: auto;
   }
   .pr-settings-title {
     font-size: 11px;
     font-weight: 600;
-    color: #888;
+    color: #aaa !important;
     text-transform: uppercase;
     letter-spacing: 0.06em;
     padding-bottom: 4px;
-    border-bottom: 1px solid #333;
+    border-bottom: 1px solid #3a3a3a;
     margin-bottom: 2px;
   }
   .pr-settings-row {
@@ -413,9 +453,27 @@ const STYLES = `
   }
   .pr-settings-label {
     font-size: 12px;
-    color: #bbb;
+    color: #ccc !important;
     flex: 1;
     white-space: nowrap;
+  }
+  .pr-settings-field {
+    background: #2c2c2c !important;
+    color: #e0e0e0 !important;
+    border: 1px solid #4a4a4a !important;
+    border-radius: 4px;
+    padding: 4px 6px;
+    font-size: 12px;
+    outline: none;
+    cursor: pointer;
+    box-sizing: border-box;
+  }
+  .pr-settings-field:focus {
+    border-color: #6a6aaa !important;
+  }
+  .pr-settings-field option {
+    background: #2c2c2c;
+    color: #e0e0e0;
   }
   .pr-number-control {
     display: flex;
@@ -1063,10 +1121,33 @@ class TimelineEditor {
     const propContainer = document.createElement("div");
     propContainer.className = "pr-prop-container";
 
+    // --- Hint row (persists across generations — VLM instruction per segment) ---
+    const hintRow = document.createElement("div");
+    hintRow.className = "pr-hint-row";
+
+    const hintLabel = document.createElement("span");
+    hintLabel.className = "pr-hint-label";
+    hintLabel.textContent = "✨ Hint";
+    hintLabel.title = "Stays intact after generation. Guides each image differently (e.g. 'balletto', 'lotta').";
+
+    this.hintInput = document.createElement("input");
+    this.hintInput.type = "text";
+    this.hintInput.className = "pr-hint-input";
+    this.hintInput.placeholder = "scene hint for ✨ generation (e.g. balletto, lotta, slow sunset walk)…";
+    this.hintInput.addEventListener("input", () => {
+      if (this.selectionType === "image" && this.timeline.segments[this.selectedIndex]) {
+        this.timeline.segments[this.selectedIndex].hint = this.hintInput.value;
+        this.commitChanges();
+      }
+    });
+
+    hintRow.appendChild(hintLabel);
+    hintRow.appendChild(this.hintInput);
+
     // --- Text Area (Image/Text) ---
     this.promptInput = document.createElement("textarea");
     this.promptInput.className = "pr-prompt-area";
-    this.promptInput.placeholder = "Enter prompt for selected segment...";
+    this.promptInput.placeholder = "Generated prompt — edit freely. Fill ✨ Hint above to guide the next generation.";
     this.promptInput.addEventListener("input", () => {
       if (this.selectionType === "image" && this.timeline.segments[this.selectedIndex]) {
         this.timeline.segments[this.selectedIndex].prompt = this.promptInput.value;
@@ -1078,6 +1159,7 @@ class TimelineEditor {
     this.audioInfoArea = document.createElement("div");
     this.audioInfoArea.className = "pr-audio-info";
 
+    propContainer.appendChild(hintRow);
     propContainer.appendChild(this.promptInput);
     propContainer.appendChild(this.audioInfoArea);
 
@@ -1750,6 +1832,9 @@ class TimelineEditor {
       if (seg) {
         this.promptInput.value = seg.prompt || "";
         this.promptInput.disabled = false;
+        this.hintInput.value = seg.hint || "";
+        this.hintInput.disabled = false;
+        this.hintInput.closest(".pr-hint-row").style.display = "flex";
 
         const isImage = seg.type !== "text";
         const strength = isImage ? (seg.guideStrength ?? 1.0) : 1.0;
@@ -1758,6 +1843,9 @@ class TimelineEditor {
       } else {
         this.promptInput.value = "";
         this.promptInput.disabled = true;
+        this.hintInput.value = "";
+        this.hintInput.disabled = true;
+        this.hintInput.closest(".pr-hint-row").style.display = "none";
         this.strengthValue.value = "1.00";
         this.strengthValue.disabled = true;
       }
@@ -3595,7 +3683,7 @@ class TimelineEditor {
 
     // Vision model dropdown
     const modelSel = document.createElement("select");
-    modelSel.className = "pr-settings-input";
+    modelSel.className = "pr-settings-field";
     modelSel.style.width = "100%";
     const vlmModelOptions = [
       "Qwen2.5-VL-3B — Fast",
@@ -3615,10 +3703,11 @@ class TimelineEditor {
     // Temperature
     const tempInput = document.createElement("input");
     tempInput.type = "number";
-    tempInput.className = "pr-settings-input";
+    tempInput.className = "pr-settings-field";
     tempInput.min = 0; tempInput.max = 2; tempInput.step = 0.05;
     tempInput.value = vlmCfg.temperature;
     tempInput.style.width = "70px";
+    tempInput.style.textAlign = "center";
     tempInput.addEventListener("change", () => {
       const c = this._getVlmConfig(); c.temperature = parseFloat(tempInput.value) ?? 0.3; this._setVlmConfig(c);
     });
@@ -3627,10 +3716,11 @@ class TimelineEditor {
     // Max tokens
     const maxTokInput = document.createElement("input");
     maxTokInput.type = "number";
-    maxTokInput.className = "pr-settings-input";
+    maxTokInput.className = "pr-settings-field";
     maxTokInput.min = 32; maxTokInput.max = 512; maxTokInput.step = 1;
     maxTokInput.value = vlmCfg.max_tokens;
     maxTokInput.style.width = "70px";
+    maxTokInput.style.textAlign = "center";
     maxTokInput.addEventListener("change", () => {
       const c = this._getVlmConfig(); c.max_tokens = parseInt(maxTokInput.value) || 180; this._setVlmConfig(c);
     });
@@ -3649,14 +3739,116 @@ class TimelineEditor {
     // Local model path
     const localPathInput = document.createElement("input");
     localPathInput.type = "text";
-    localPathInput.className = "pr-settings-input";
+    localPathInput.className = "pr-settings-field";
     localPathInput.style.width = "100%";
     localPathInput.value = vlmCfg.local_path;
-    localPathInput.placeholder = "Optional: path to local model snapshot";
+    localPathInput.placeholder = "Dir with config.json (HF), dir with .gguf, or .gguf file path";
     localPathInput.addEventListener("change", () => {
       const c = this._getVlmConfig(); c.local_path = localPathInput.value.trim(); this._setVlmConfig(c);
     });
     menu.appendChild(this._makeSettingRow("Local Path", localPathInput));
+
+    // mmproj path (for GGUF vision models — auto-detected if left empty)
+    const mmProjInput = document.createElement("input");
+    mmProjInput.type = "text";
+    mmProjInput.className = "pr-settings-field";
+    mmProjInput.style.width = "100%";
+    mmProjInput.value = vlmCfg.mmproj_path;
+    mmProjInput.placeholder = "mmproj .gguf — auto-detected from Local Path dir";
+    mmProjInput.addEventListener("change", () => {
+      const c = this._getVlmConfig(); c.mmproj_path = mmProjInput.value.trim(); this._setVlmConfig(c);
+    });
+    menu.appendChild(this._makeSettingRow("mmproj Path", mmProjInput));
+
+    // --- Style Directives ---
+    const styleDivider = document.createElement("hr");
+    styleDivider.className = "pr-settings-divider";
+    menu.appendChild(styleDivider);
+
+    const styleTitle = document.createElement("div");
+    styleTitle.className = "pr-vlm-section-title";
+    styleTitle.textContent = "Style Directives";
+    menu.appendChild(styleTitle);
+
+    const _makeVlmSelect = (options, currentVal, key) => {
+      const sel = document.createElement("select");
+      sel.className = "pr-settings-field";
+      sel.style.width = "100%";
+      options.forEach(opt => {
+        const o = document.createElement("option");
+        o.value = opt; o.textContent = opt;
+        if (opt === currentVal) o.selected = true;
+        sel.appendChild(o);
+      });
+      sel.addEventListener("change", () => {
+        const c = this._getVlmConfig(); c[key] = sel.value; this._setVlmConfig(c);
+      });
+      return sel;
+    };
+
+    // Style Preset — options loaded dynamically from Python STYLE_PRESETS dict
+    const presetRow = this._makeSettingRow("Style Preset", (() => {
+      const sel = document.createElement("select");
+      sel.className = "pr-settings-field";
+      sel.style.width = "100%";
+      const _fillPresetSel = (names) => {
+        sel.innerHTML = "";
+        names.forEach(opt => {
+          const o = document.createElement("option");
+          o.value = opt; o.textContent = opt;
+          if (opt === vlmCfg.style_preset) o.selected = true;
+          sel.appendChild(o);
+        });
+      };
+      // Populate from server; fall back to a minimal list on error
+      api.fetchApi("/whatdreamscost/style_presets")
+        .then(r => r.json())
+        .then(d => { if (d.presets?.length) _fillPresetSel(d.presets); })
+        .catch(() => _fillPresetSel(["None — let VLM decide"]));
+      sel.addEventListener("change", () => {
+        const c = this._getVlmConfig(); c.style_preset = sel.value; this._setVlmConfig(c);
+      });
+      return sel;
+    })());
+    menu.appendChild(presetRow);
+
+    menu.appendChild(this._makeSettingRow("Shot Angle", _makeVlmSelect([
+      "None — let VLM decide",
+      "Wide shot",
+      "Medium shot",
+      "Close-up",
+      "Extreme close-up",
+      "Aerial / Bird's eye",
+      "Low angle",
+      "Over the shoulder",
+      "POV",
+    ], vlmCfg.shot_angle, "shot_angle")));
+
+    menu.appendChild(this._makeSettingRow("Camera Movement", _makeVlmSelect([
+      "None — let VLM decide",
+      "Static",
+      "Slow dolly in",
+      "Slow dolly out",
+      "Gentle pan left",
+      "Gentle pan right",
+      "Tilt up",
+      "Tilt down",
+      "Tracking shot",
+      "Handheld",
+      "Crane / Boom up",
+      "Circular orbit",
+    ], vlmCfg.camera_move, "camera_move")));
+
+    const styleExtraInput = document.createElement("input");
+    styleExtraInput.type = "text";
+    styleExtraInput.className = "pr-settings-field";
+    styleExtraInput.style.width = "100%";
+    styleExtraInput.value = vlmCfg.style_extra;
+    styleExtraInput.placeholder = "e.g. warm golden light, shallow DOF";
+    styleExtraInput.addEventListener("change", () => {
+      const c = this._getVlmConfig(); c.style_extra = styleExtraInput.value.trim(); this._setVlmConfig(c);
+    });
+    menu.appendChild(this._makeSettingRow("Extra Instruction", styleExtraInput));
 
     // --- Show/Hide on Node Toggle ---
     const toggleBtn = document.createElement("button");
@@ -3714,6 +3906,11 @@ class TimelineEditor {
       max_tokens:   raw.max_tokens   ?? 180,
       offline_mode: raw.offline_mode ?? false,
       local_path:   raw.local_path   ?? "",
+      mmproj_path:  raw.mmproj_path  ?? "",
+      style_preset: raw.style_preset ?? "None — let VLM decide",
+      shot_angle:   raw.shot_angle   ?? "None — let VLM decide",
+      camera_move:  raw.camera_move  ?? "None — let VLM decide",
+      style_extra:  raw.style_extra  ?? "",
     };
   }
 
@@ -3749,6 +3946,7 @@ class TimelineEditor {
         segments: this.timeline.segments.map(s => ({
           imageB64:  s.imageB64  || null,
           imageFile: s.imageFile || null,
+          hint:      s.hint      || "",
           prompt:    s.prompt    || "",
           type:      s.type      || "image",
         })),
@@ -3758,6 +3956,11 @@ class TimelineEditor {
         max_tokens:    cfg.max_tokens,
         offline_mode:  cfg.offline_mode,
         local_path:    cfg.local_path,
+        mmproj_path:   cfg.mmproj_path,
+        style_preset:  cfg.style_preset,
+        shot_angle:    cfg.shot_angle,
+        camera_move:   cfg.camera_move,
+        style_extra:   cfg.style_extra,
       };
 
       const resp = await api.fetchApi("/whatdreamscost/generate_prompts", {

--- a/js/ltx_director.js
+++ b/js/ltx_director.js
@@ -79,6 +79,28 @@ const STYLES = `
     border-color: #cc4444;
     color: #ffaaaa;
   }
+  .pr-btn-vlm {
+    background: #1a1a2e;
+    border-color: #3a3a6e;
+    color: #b0b0ff;
+  }
+  .pr-btn-vlm:hover {
+    background: #2a2a4e;
+    border-color: #6060cc;
+    color: #d0d0ff;
+  }
+  .pr-btn-vlm:disabled {
+    opacity: 0.55;
+    cursor: not-allowed;
+  }
+  .pr-vlm-section-title {
+    font-size: 10px;
+    font-weight: 600;
+    color: #888;
+    text-transform: uppercase;
+    letter-spacing: 0.8px;
+    padding: 4px 0 2px 0;
+  }
   .pr-canvas {
     border-radius: 6px;
     border: 1px solid #111;
@@ -883,11 +905,30 @@ class TimelineEditor {
     deleteBtn.innerHTML = `${ICONS.trash} Delete`;
     deleteBtn.addEventListener("click", () => this.deleteSelectedSegment());
 
+    const generatePromptsBtn = document.createElement("button");
+    generatePromptsBtn.className = "pr-btn pr-btn-vlm";
+    generatePromptsBtn.innerHTML = "✨ Prompts";
+    generatePromptsBtn.title = "Generate prompts for all image segments using Qwen2.5-VL. Configure in Settings (⚙️).";
+    generatePromptsBtn.addEventListener("click", (e) => {
+      e.stopPropagation();
+      this.generatePrompts(generatePromptsBtn);
+    });
+    this._generatePromptsBtn = generatePromptsBtn;
+    // Sync disabled state from saved config
+    setTimeout(() => {
+      const vlmInitCfg = this._getVlmConfig();
+      if (!vlmInitCfg.enabled) {
+        generatePromptsBtn.disabled = true;
+        generatePromptsBtn.title = "Prompt Writer is disabled. Enable it in Settings (⚙️).";
+      }
+    }, 0);
+
     actionGroup.appendChild(this.fileInput);
     actionGroup.appendChild(this.audioFileInput);
     actionGroup.appendChild(uploadBtn);
     actionGroup.appendChild(addTextBtn);
     actionGroup.appendChild(uploadAudioBtn);
+    actionGroup.appendChild(generatePromptsBtn);
     actionGroup.appendChild(deleteBtn);
     toolbar.appendChild(actionGroup);
 
@@ -3522,6 +3563,101 @@ class TimelineEditor {
     }
 
 
+    // --- VLM Prompt Writer Config ---
+    const vlmDivider = document.createElement("hr");
+    vlmDivider.className = "pr-settings-divider";
+    menu.appendChild(vlmDivider);
+
+    const vlmTitle = document.createElement("div");
+    vlmTitle.className = "pr-vlm-section-title";
+    vlmTitle.textContent = "Prompt Writer (Qwen2.5-VL)";
+    menu.appendChild(vlmTitle);
+
+    const vlmCfg = this._getVlmConfig();
+
+    // Enable toggle
+    const enabledCb = document.createElement("input");
+    enabledCb.type = "checkbox";
+    enabledCb.checked = vlmCfg.enabled;
+    enabledCb.style.cursor = "pointer";
+    enabledCb.addEventListener("change", () => {
+      const c = this._getVlmConfig();
+      c.enabled = enabledCb.checked;
+      this._setVlmConfig(c);
+      if (this._generatePromptsBtn) {
+        this._generatePromptsBtn.disabled = !c.enabled;
+        this._generatePromptsBtn.title = c.enabled
+          ? "Generate prompts for all image segments using Qwen2.5-VL. Configure in Settings (⚙️)."
+          : "Prompt Writer is disabled. Enable it in Settings (⚙️).";
+      }
+    });
+    menu.appendChild(this._makeSettingRow("Enable Prompt Writer", enabledCb));
+
+    // Vision model dropdown
+    const modelSel = document.createElement("select");
+    modelSel.className = "pr-settings-input";
+    modelSel.style.width = "100%";
+    const vlmModelOptions = [
+      "Qwen2.5-VL-3B — Fast",
+      "Qwen2.5-VL-7B — Best quality",
+    ];
+    vlmModelOptions.forEach(opt => {
+      const o = document.createElement("option");
+      o.value = opt; o.textContent = opt;
+      if (opt === vlmCfg.model_name) o.selected = true;
+      modelSel.appendChild(o);
+    });
+    modelSel.addEventListener("change", () => {
+      const c = this._getVlmConfig(); c.model_name = modelSel.value; this._setVlmConfig(c);
+    });
+    menu.appendChild(this._makeSettingRow("Vision Model", modelSel));
+
+    // Temperature
+    const tempInput = document.createElement("input");
+    tempInput.type = "number";
+    tempInput.className = "pr-settings-input";
+    tempInput.min = 0; tempInput.max = 2; tempInput.step = 0.05;
+    tempInput.value = vlmCfg.temperature;
+    tempInput.style.width = "70px";
+    tempInput.addEventListener("change", () => {
+      const c = this._getVlmConfig(); c.temperature = parseFloat(tempInput.value) ?? 0.3; this._setVlmConfig(c);
+    });
+    menu.appendChild(this._makeSettingRow("Temperature", tempInput));
+
+    // Max tokens
+    const maxTokInput = document.createElement("input");
+    maxTokInput.type = "number";
+    maxTokInput.className = "pr-settings-input";
+    maxTokInput.min = 32; maxTokInput.max = 512; maxTokInput.step = 1;
+    maxTokInput.value = vlmCfg.max_tokens;
+    maxTokInput.style.width = "70px";
+    maxTokInput.addEventListener("change", () => {
+      const c = this._getVlmConfig(); c.max_tokens = parseInt(maxTokInput.value) || 180; this._setVlmConfig(c);
+    });
+    menu.appendChild(this._makeSettingRow("Max Tokens", maxTokInput));
+
+    // Offline mode
+    const offlineCb = document.createElement("input");
+    offlineCb.type = "checkbox";
+    offlineCb.checked = vlmCfg.offline_mode;
+    offlineCb.style.cursor = "pointer";
+    offlineCb.addEventListener("change", () => {
+      const c = this._getVlmConfig(); c.offline_mode = offlineCb.checked; this._setVlmConfig(c);
+    });
+    menu.appendChild(this._makeSettingRow("Offline Mode", offlineCb));
+
+    // Local model path
+    const localPathInput = document.createElement("input");
+    localPathInput.type = "text";
+    localPathInput.className = "pr-settings-input";
+    localPathInput.style.width = "100%";
+    localPathInput.value = vlmCfg.local_path;
+    localPathInput.placeholder = "Optional: path to local model snapshot";
+    localPathInput.addEventListener("change", () => {
+      const c = this._getVlmConfig(); c.local_path = localPathInput.value.trim(); this._setVlmConfig(c);
+    });
+    menu.appendChild(this._makeSettingRow("Local Path", localPathInput));
+
     // --- Show/Hide on Node Toggle ---
     const toggleBtn = document.createElement("button");
     toggleBtn.className = "pr-settings-toggle-btn";
@@ -3566,6 +3702,99 @@ class TimelineEditor {
   dismissSettingsMenu() {
     if (this._settingsMenu) { this._settingsMenu.remove(); this._settingsMenu = null; }
     if (this._settingsDismisser) { document.removeEventListener("mousedown", this._settingsDismisser); this._settingsDismisser = null; }
+  }
+
+  _getVlmConfig() {
+    let raw = {};
+    try { raw = JSON.parse(localStorage.getItem("wdc_vlm_config") || "{}"); } catch {}
+    return {
+      enabled:      raw.enabled      ?? true,
+      model_name:   raw.model_name   ?? "Qwen2.5-VL-3B — Fast",
+      temperature:  raw.temperature  ?? 0.3,
+      max_tokens:   raw.max_tokens   ?? 180,
+      offline_mode: raw.offline_mode ?? false,
+      local_path:   raw.local_path   ?? "",
+    };
+  }
+
+  _setVlmConfig(cfg) {
+    localStorage.setItem("wdc_vlm_config", JSON.stringify(cfg));
+  }
+
+  async generatePrompts(btn) {
+    const cfg = this._getVlmConfig();
+
+    if (!cfg.enabled) {
+      alert("Prompt Writer is disabled.\nEnable it in Settings (⚙️) → Prompt Writer section.");
+      return;
+    }
+
+    const imageSections = this.timeline.segments.filter(
+      s => s.type !== "text" && (s.imageB64 || s.imageFile)
+    );
+    if (imageSections.length === 0) {
+      alert("No image segments found on the timeline.\nAdd images first, then click Generate Prompts.");
+      return;
+    }
+
+    const origHTML = btn.innerHTML;
+    const setBtn = (html, disabled) => { btn.innerHTML = html; btn.disabled = disabled; };
+    setBtn(`⏳ 0/${imageSections.length}…`, true);
+
+    try {
+      const globalPromptWidget = this.node.widgets?.find(w => w.name === "global_prompt");
+      const globalPrompt = globalPromptWidget?.value || "";
+
+      const payload = {
+        segments: this.timeline.segments.map(s => ({
+          imageB64:  s.imageB64  || null,
+          imageFile: s.imageFile || null,
+          prompt:    s.prompt    || "",
+          type:      s.type      || "image",
+        })),
+        global_prompt: globalPrompt,
+        model_name:    cfg.model_name,
+        temperature:   cfg.temperature,
+        max_tokens:    cfg.max_tokens,
+        offline_mode:  cfg.offline_mode,
+        local_path:    cfg.local_path,
+      };
+
+      const resp = await api.fetchApi("/whatdreamscost/generate_prompts", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+
+      const data = await resp.json();
+      if (!resp.ok || data.error) throw new Error(data.error || `Server error ${resp.status}`);
+
+      const prompts = data.prompts || [];
+      let filled = 0;
+      prompts.forEach((p, i) => {
+        if (i < this.timeline.segments.length && p) {
+          this.timeline.segments[i].prompt = p;
+          if (this.timeline.segments[i].type !== "text" && (this.timeline.segments[i].imageB64 || this.timeline.segments[i].imageFile)) {
+            filled++;
+          }
+        }
+      });
+
+      if (this.selectionType === "image" && this.selectedIndex >= 0
+          && this.selectedIndex < this.timeline.segments.length) {
+        this.promptInput.value = this.timeline.segments[this.selectedIndex].prompt || "";
+      }
+
+      this.commitChanges();
+      this.render();
+
+      setBtn(`✓ ${filled} done`, true);
+      setTimeout(() => { setBtn(origHTML, false); }, 2500);
+    } catch (e) {
+      setBtn("✗ Error", true);
+      setTimeout(() => { setBtn(origHTML, false); }, 3000);
+      alert(`Prompt generation failed:\n\n${e.message}`);
+    }
   }
 
 

--- a/ltx_prompt_writer.py
+++ b/ltx_prompt_writer.py
@@ -42,7 +42,431 @@ VISION_SYSTEM_PROMPT = (
 )
 
 # ---------------------------------------------------------------------------
-# Model singleton (one vision model loaded at a time)
+# Style presets
+# ---------------------------------------------------------------------------
+# Each entry: "Preset name": "Full style instruction injected into the prompt."
+# Add new presets here — the JS dropdown is populated automatically via the
+# /whatdreamscost/style_presets endpoint; no JS edits needed.
+# ---------------------------------------------------------------------------
+
+_NONE_STYLE_LABEL = "None — let VLM decide"
+
+STYLE_PRESETS: dict[str, str] = {
+    _NONE_STYLE_LABEL: "",
+    "Cinematic — Drama": (
+        "STYLE: Cinematic drama. Intimate, character-driven. Shallow depth of field — subject sharp, "
+        "world behind them soft. Colour grade: cool shadows, warm skin tones, restrained palette. "
+        "Camera: medium close-ups and close-ups dominate. Moves are slow and purposeful — "
+        "a slow push-in on a face, a rack focus between two people, a static hold that lets the actor breathe. "
+        "Lighting: motivated practical sources — a lamp, a window, a candle. Never flat."
+    ),
+    "Cinematic — Epic": (
+        "STYLE: Epic cinematic. Scale and environment are the protagonist. "
+        "Wide establishing shots and vast compositions that make people feel small against the world. "
+        "Camera: sweeping crane moves, slow lateral tracking shots, long pulls across terrain. "
+        "Colour grade: rich, contrasty — deep shadows, luminous highlights. "
+        "Every frame should feel like a poster. Build depth with foreground elements. "
+        "Natural motion blur on all movement."
+    ),
+    "Cinematic — Intimate close-up": (
+        "STYLE: Intimate close-up cinema. The entire world is a face, a hand, a detail. "
+        "Razor-thin depth of field — one eye sharp, the other already soft. Bokeh is smooth and organic. "
+        "Framing: extreme close-ups only — fill the frame with a face or a single feature. "
+        "Camera: barely moves — micro drifts and imperceptible breathing movement. "
+        "Colour grade: skin-tone faithful, warm and close. Lighting: one soft source, one fill, nothing else."
+    ),
+    "Slow-burn thriller": (
+        "STYLE: Slow-burn psychological thriller. Tight framing, long held shots, shallow depth of field. "
+        "Colour palette: desaturated teal and amber. Camera moves deliberately and slowly. "
+        "Tension built through restraint, not action."
+    ),
+    "Handheld documentary": (
+        "STYLE: Handheld documentary. Camera moves with the subject, never static. Slight shake on movement. "
+        "Natural available light only — no studio lighting. Colour grade: flat, slightly washed. "
+        "Intimate and observational — camera follows, never leads."
+    ),
+    "Horror — desaturated, harsh contrast": (
+        "STYLE: Horror. Heavily desaturated colour, crushed blacks. Harsh top-down or under-lighting. "
+        "Camera movements are slow and uneasy — never reassuring. "
+        "Framing leaves negative space — empty doorways, dark corners. No warmth in the image."
+    ),
+    "Golden hour drama": (
+        "STYLE: Golden hour drama. Warm amber and orange light from a low sun. Heavy lens flare. "
+        "Soft shadows, glowing skin tones. Wide establishing shots and medium shots. "
+        "Emotional, sweeping camera movement. Colour grade: warm, slightly overexposed highlights."
+    ),
+    "Noir — deep shadows, venetian light": (
+        "STYLE: Classic noir. Low-key lighting, venetian blind shadow patterns across faces and walls. "
+        "Black and white or heavily desaturated with single colour accent. "
+        "Camera angles: low, Dutch tilt, shot through objects. Mood is foreboding and fatalistic."
+    ),
+    "High fashion editorial": (
+        "STYLE: High fashion editorial. Striking, composed frames. Hard directional lighting with deep shadows. "
+        "Colour palette: high contrast, often monochrome or single accent colour. "
+        "Movement is deliberate and posed — model-aware. Camera movements are slow and precise. "
+        "Apply the editorial aesthetic to whatever location the user specified."
+    ),
+    "Music video — stylised": (
+        "STYLE: Music video. Rhythm-cut visual language — movement is driven by the beat. "
+        "High contrast colour grade with stylised palette. "
+        "Mix of tight close-ups and dramatic wide shots. Camera movement is expressive, not documentary. "
+        "Film the scene the user described, through a music video camera."
+    ),
+    "Action blockbuster": (
+        "STYLE: Action blockbuster. Fast kinetic energy. Dutch angles, crash zooms, whip pans. "
+        "Colour grade: teal and orange, high contrast. "
+        "Camera is never still — it moves with every impact. Slow motion inserts on key moments."
+    ),
+    "Sports documentary": (
+        "STYLE: Sports documentary. Tracking shots following the athlete. Telephoto compression. "
+        "Slow motion bursts at peak moments. Natural sound — crowd noise, impact, breathing. "
+        "Colour grade: clean and neutral. Camera is athletic — it moves like it is competing too."
+    ),
+    "Dreamy — soft focus, slow motion": (
+        "STYLE: Dreamy aesthetic. Soft focus edges with sharp centre. Pastel colour bleed. "
+        "Movement is slow — the frame breathes rather than cuts. "
+        "Shallow depth of field with heavy bokeh. Light sources bloom and halo."
+    ),
+    "Lo-fi home video — VHS": (
+        "STYLE: Lo-fi home video. VHS tape aesthetic — slightly washed colour, faint scan lines, soft edges. "
+        "Colour grade: faded, slightly green-shifted. Camera is handheld and casual. "
+        "Intimate domestic setting implied. Imperfection is the aesthetic."
+    ),
+    "Hyper-real 4K — clinical sharpness": (
+        "STYLE: Hyper-real 4K. Clinical sharpness — every texture, pore, and fibre rendered in full detail. "
+        "Even lighting, no blown highlights, no crushed blacks. "
+        "Camera movement is minimal and precise. The image is almost uncomfortably detailed."
+    ),
+    "Gritty realism — flat, natural light": (
+        "STYLE: Gritty realism. Flat colour grade, no cinematic enhancement. Natural light only — "
+        "whatever is available in the location. Camera is direct and unsentimental. "
+        "No stylisation. The scene is shot as if it is actually happening."
+    ),
+    "POV — first person, immersive": (
+        "STYLE: First-person POV. The camera IS the viewer's eyes. "
+        "Frame moves as a head would — natural breathing movement, slight tilt on turns. "
+        "Everything is seen, not watched. Close physical detail — hands, surfaces, faces at speaking distance."
+    ),
+    "Amateur — naturalistic, raw": (
+        "STYLE: Amateur home video aesthetic. Slightly overexposed. Natural indoor lighting — lamps, overhead. "
+        "Camera is handheld and slightly uncertain. No cinematic framing. "
+        "Colour: ungraded, as-shot. The imperfection is intentional."
+    ),
+    "Anime — Japanese animation": (
+        "STYLE: Japanese anime. Hand-drawn animation aesthetic — clean ink outlines, flat colour fills with "
+        "subtle cel shading. Large expressive eyes, stylised facial features. "
+        "Colour palette: vivid, high saturation with strong accent colours. "
+        "Motion: fluid on key poses, held on reaction shots. "
+        "Render every subject in this style regardless of what was described."
+    ),
+    "2D cartoon — hand-drawn": (
+        "STYLE: Classic hand-drawn 2D cartoon. Expressive ink outlines with variable line weight. "
+        "Flat colour fills, minimal shading, bold colour palette. "
+        "Movement uses squash-and-stretch. Background art is simplified and stylised, never photorealistic. "
+        "Render every subject in this style regardless of what was described."
+    ),
+    "3D CGI — Pixar/DreamWorks": (
+        "STYLE: High-end 3D CGI animation in the style of Pixar or DreamWorks. "
+        "Subsurface scattering on skin and organic surfaces. Highly detailed surface textures. "
+        "Warm, soft three-point lighting with gentle shadows. "
+        "Camera: smooth cinematic moves — slow push-ins, arcing lateral tracks. "
+        "Colour grade: warm, slightly saturated, storybook palette. "
+        "Render every subject in this style regardless of what was described."
+    ),
+    "Sci-fi — cinematic, practical": (
+        "STYLE: Cinematic science fiction. Clean, practical-feeling environments — metal corridors, "
+        "reinforced glass, industrial lighting rigs. Colour palette: cool blue-white with accent LEDs. "
+        "No fantasy or magic — everything looks functional and built. "
+        "Camera: wide establishing shots then close on faces or hands for intimacy. Lens flare on light sources."
+    ),
+    "Cyberpunk neon illustrated": (
+        "STYLE: Cyberpunk illustrated. Neon-lit urban environment — magenta, cyan, electric blue, acid green. "
+        "Hard rim lighting from neon signs carves subjects out of near-total darkness. "
+        "Rain-slick surfaces reflect light in pools and streaks. "
+        "Camera: low angles, wide lenses, dramatic fog and haze."
+    ),
+    "Comic book / graphic novel": (
+        "STYLE: Comic book or graphic novel. Bold ink outlines, halftone dot patterns in shadow areas. "
+        "Colour is flat with hard-edged shadows. Speed lines radiate from points of impact. "
+        "Camera moves like a comic panel transition — hard cuts between angles, no smooth motion blur. "
+        "Render every subject in this style regardless of what was described."
+    ),
+    "Erotic cinema — tasteful, cinematic": (
+        "STYLE: Tasteful erotic cinema. Warm, intimate lighting — practical sources only. "
+        "Shallow depth of field. Camera moves slowly and deliberately. "
+        "Colour grade: warm skin tones, soft highlights. "
+        "Sensual but not pornographic — implication over explicit detail. Slow, breathing pace. "
+        "Describe only what was asked for — the style wraps it, it does not expand it."
+    ),
+    "Explicit — direct, anatomical": (
+        "STYLE: Explicit adult content. Direct lighting — bodies clearly lit with no flattering shadow. "
+        "Camera is close and functional — shows exactly what is happening without cinematic softening. "
+        "No romantic framing. Blunt and specific. Anatomical language used directly. "
+        "Describe only what the user requested. Do not add acts or nudity the user did not write."
+    ),
+    "Voyeur — handheld, observational": (
+        "STYLE: Voyeuristic. The camera is a person — someone who found this moment and is trying not to be noticed. "
+        "The camera bobs and drifts with the natural sway of someone standing. "
+        "The motion is involuntary — slight vertical bounce, gentle lateral drift, micro-rotations. "
+        "The camera NEVER repositions to get a better angle. Natural available light only — no fill, no flash. "
+        "The subject is unaware. The camera does not announce itself."
+    ),
+    "Softcore editorial — lingerie-adjacent": (
+        "STYLE: Softcore editorial. Fashion-magazine aesthetic. Clean, even lighting. "
+        "Colour grade: warm neutrals and soft pastels. "
+        "Camera is composed — lingerie-level sensuality, no explicit content. Movement is slow and posed. "
+        "Do NOT add undressing, nudity, or intimate acts the user did not ask for."
+    ),
+    "Gravure Idol — Japanese glamour": (
+        "STYLE: Japanese gravure idol photoshoot / glamour video. "
+        "Bright, glossy, commercial magazine aesthetic. "
+        "High-key natural daylight or clean studio lighting with strong rim light and soft reflector fill. "
+        "Vivid yet smooth skin tones, slightly increased saturation, polished and flattering look. "
+        "Posing is intentional, playful and seductive: arched back, teasing eye contact. "
+        "Camera movement: slow body pan, lingering holds, slow tilt up, push-in as she makes eye contact. "
+        "Mood is cute-provocative: youthful charm combined with fan-service energy."
+    ),
+    "Femdom — verbal domination": (
+        "STYLE: Femdom verbal domination. She is the only power in the room. "
+        "Camera worships her — low angle looking up, slow orbital arc, close-up on her expression of contempt. "
+        "Hard directional lighting — one side of her face in clean harsh light, one in shadow. "
+        "Her voice is the dominant sound — every consonant audible. "
+        "FORBIDDEN: softness, uncertainty, the dominant losing composure."
+    ),
+    "Portrait vertical — 9:16 mobile": (
+        "STYLE: Native portrait video, 9:16 aspect ratio. Optimised for mobile — TikTok, Reels, Shorts. "
+        "Frame is vertical throughout. Tight head-to-torso framing. "
+        "Action moves vertically in frame. Camera stays close. No wide horizontal composition."
+    ),
+    "Selfie — self-shot, arm's length": (
+        "STYLE: Self-shot selfie video. The subject is holding the camera themselves — "
+        "outstretched arm, camera facing back at them. 9:16 vertical frame. "
+        "Tight head-and-shoulders framing. Camera bobs as they move, tilts when they turn their head. "
+        "FORBIDDEN: tripod stillness, gimbal smoothness, rack focus, dolly, crane. "
+        "Colour: clean and bright, natural available light, no cinematic grade."
+    ),
+    # ── Add your own presets below this line ─────────────────────────────────
+}
+
+# ---------------------------------------------------------------------------
+# GGUF path helpers
+# ---------------------------------------------------------------------------
+
+def _resolve_gguf_path(local_path: str) -> tuple[str | None, bool]:
+    """Returns (gguf_file, is_gguf_mode).
+
+    is_gguf_mode is True when local_path is a .gguf file directly, or a
+    directory that contains .gguf files but no config.json (i.e. not a
+    HuggingFace transformers snapshot).
+    """
+    if not local_path:
+        return None, False
+    lp = local_path.strip()
+    if not lp:
+        return None, False
+    if os.path.isfile(lp) and lp.lower().endswith(".gguf"):
+        return lp, True
+    if os.path.isdir(lp):
+        if os.path.exists(os.path.join(lp, "config.json")):
+            return None, False  # valid transformers dir — not GGUF mode
+        candidates = sorted(
+            [f for f in os.listdir(lp)
+             if f.lower().endswith(".gguf") and "mmproj" not in f.lower()],
+            key=lambda f: os.path.getsize(os.path.join(lp, f)),
+            reverse=True,
+        )
+        if candidates:
+            return os.path.join(lp, candidates[0]), True
+    return None, False
+
+
+def _find_mmproj(gguf_file: str, mmproj_hint: str = "") -> str | None:
+    """Return mmproj path: use hint if valid, otherwise scan same directory."""
+    if mmproj_hint.strip() and os.path.isfile(mmproj_hint.strip()):
+        return mmproj_hint.strip()
+    directory = os.path.dirname(gguf_file)
+    for fname in os.listdir(directory):
+        if fname.lower().endswith(".gguf") and "mmproj" in fname.lower():
+            return os.path.join(directory, fname)
+    return None
+
+
+# ---------------------------------------------------------------------------
+# GGUF model singleton
+# ---------------------------------------------------------------------------
+
+_gguf_llm = None
+_gguf_llm_key: str | None = None
+
+
+def _unload_gguf_model() -> None:
+    global _gguf_llm, _gguf_llm_key
+    if _gguf_llm is None:
+        return
+    _gguf_llm = None
+    _gguf_llm_key = None
+    gc.collect()
+    log.info("[PromptWriter] GGUF model unloaded.")
+
+
+def _load_gguf_model(gguf_file: str, mmproj_file: str | None):
+    global _gguf_llm, _gguf_llm_key
+
+    cache_key = f"{gguf_file}|{mmproj_file or ''}"
+    if _gguf_llm_key == cache_key:
+        return _gguf_llm
+
+    _unload_gguf_model()
+    _unload_vision_model()  # only one backend loaded at a time
+
+    try:
+        import comfy.model_management as mm
+        mm.unload_all_models()
+        mm.soft_empty_cache()
+    except Exception:
+        pass
+
+    from llama_cpp import Llama
+
+    kwargs: dict = dict(
+        model_path=gguf_file,
+        n_ctx=8192,
+        n_gpu_layers=-1,
+        verbose=False,
+    )
+
+    if mmproj_file:
+        handler_cls = None
+        # Try handlers in order of preference
+        for cls_name in ("Qwen35ChatHandler", "Qwen2VLChatHandler", "Qwen2_5VLChatHandler"):
+            try:
+                from llama_cpp import llama_chat_format as _lcf
+                handler_cls = getattr(_lcf, cls_name)
+                log.info("[PromptWriter] Using %s for vision", cls_name)
+                break
+            except (ImportError, AttributeError):
+                continue
+
+        if handler_cls:
+            try:
+                # enable_thinking=False disables chain-of-thought (Qwen3.5 specific)
+                try:
+                    kwargs["chat_handler"] = handler_cls(
+                        clip_model_path=mmproj_file, verbose=False, enable_thinking=False
+                    )
+                except TypeError:
+                    kwargs["chat_handler"] = handler_cls(
+                        clip_model_path=mmproj_file, verbose=False
+                    )
+                log.info("[PromptWriter] GGUF vision handler loaded with mmproj: %s", mmproj_file)
+            except Exception as e:
+                log.warning("[PromptWriter] Vision handler init failed (%s: %s) — text-only", type(e).__name__, e)
+        else:
+            log.warning("[PromptWriter] No VL chat handler found in llama-cpp — text-only")
+
+    _gguf_llm = Llama(**kwargs)
+    _gguf_llm_key = cache_key
+    log.info("[PromptWriter] GGUF model loaded: %s", gguf_file)
+    return _gguf_llm
+
+
+import re as _re
+
+
+def _strip_thinking(text: str) -> str:
+    """Strip <think>...</think> blocks and chain-of-thought preambles.
+
+    Strategy: after removing explicit think tags, split into paragraphs and
+    return the last one that looks like plain prose (no markdown bullets or
+    headers) and is at least 40 characters long.  This handles thinking models
+    that dump analysis before writing the actual answer.
+    """
+    # 1. Remove explicit <think> blocks
+    text = _re.sub(r"<think>[\s\S]*?</think>", "", text, flags=_re.DOTALL).strip()
+    if not text:
+        return text
+
+    # 2. Split into blank-line-separated paragraphs
+    paragraphs = [p.strip() for p in _re.split(r"\n\s*\n", text) if p.strip()]
+    if not paragraphs:
+        return text
+
+    # 3. Find last paragraph that reads as plain prose
+    bullet_or_header = _re.compile(r"^\s*(\d+[\.\)]|[-*#]|\*\*)", _re.MULTILINE)
+    for para in reversed(paragraphs):
+        # Reject if the paragraph is mostly bullets / headers / markdown bold
+        non_md = _re.sub(r"\*+[^*\n]+\*+", "", para)   # strip **bold**
+        non_md = _re.sub(r"^\s*[-*#\d]+[.)\s].*$", "", non_md, flags=_re.MULTILINE)
+        non_md = non_md.strip()
+        if len(non_md) >= 40 and not bullet_or_header.match(para):
+            return para
+
+    # 4. Hard fallback: last paragraph regardless
+    return paragraphs[-1]
+
+
+def _describe_image_gguf_sync(
+    image_tensor: torch.Tensor,
+    gguf_file: str,
+    mmproj_file: str | None,
+    user_text: str,
+    temperature: float,
+    max_tokens: int,
+) -> str:
+    import base64 as _b64
+    import io as _sio
+
+    llm = _load_gguf_model(gguf_file, mmproj_file)
+    has_vision = mmproj_file and getattr(llm, "chat_handler", None) is not None
+
+    # For thinking models (Qwen3, DeepSeek-R1, etc.) add /no_think system instruction
+    system_msg = {"role": "system", "content": "/no_think\nOutput ONLY the scene description. No reasoning, no analysis, no preamble."}
+
+    if has_vision:
+        pil = _tensor_to_pil(image_tensor)
+        buf = _sio.BytesIO()
+        pil.save(buf, format="JPEG", quality=90)
+        img_b64 = _b64.b64encode(buf.getvalue()).decode()
+        messages = [
+            system_msg,
+            {
+                "role": "user",
+                "content": [
+                    {"type": "image_url", "image_url": {"url": f"data:image/jpeg;base64,{img_b64}"}},
+                    {"type": "text", "text": user_text},
+                ],
+            },
+        ]
+    else:
+        log.info("[PromptWriter] GGUF text-only mode (no mmproj — image not analysed)")
+        # Compact prompt for text-only: avoids triggering long reasoning chains
+        textonly_prompt = (
+            "/no_think\n"
+            "Write a cinematic scene description of 100-130 words for LTX-Video 2.3.\n"
+            "Present tense. Include subjects, environment, lighting, camera angle and movement.\n"
+            "Output ONLY the description, no titles, no analysis, no preamble.\n\n"
+        )
+        if user_text:
+            # Append context/style lines from the original prompt (skip the verbose system block)
+            extra = []
+            for line in user_text.splitlines():
+                if line.startswith("Global scene context") or line.startswith("- "):
+                    extra.append(line)
+            if extra:
+                textonly_prompt += "\n".join(extra)
+        messages = [system_msg, {"role": "user", "content": textonly_prompt}]
+
+    response = llm.create_chat_completion(
+        messages=messages,
+        max_tokens=max(max_tokens, 300),
+        temperature=max(temperature, 0.01),
+    )
+    raw = response["choices"][0]["message"]["content"].strip()
+    return _strip_thinking(raw)
+
+
+# ---------------------------------------------------------------------------
+# Transformers model singleton (one vision model loaded at a time)
 # ---------------------------------------------------------------------------
 
 _executor = ThreadPoolExecutor(max_workers=1)
@@ -93,7 +517,11 @@ def _load_vision_model(model_id: str, offline_mode: bool, local_path: str):
 
     source = local_path.strip() if local_path.strip() else None
 
-    if not source or not os.path.exists(source):
+    # Only use local_path if it's a valid transformers snapshot directory
+    if source and not (os.path.isdir(source) and os.path.exists(os.path.join(source, "config.json"))):
+        source = None
+
+    if not source:
         try:
             from huggingface_hub import snapshot_download
             source = snapshot_download(
@@ -137,6 +565,44 @@ def _tensor_to_pil(tensor: torch.Tensor) -> Image.Image:
     return Image.fromarray(arr)
 
 
+_NONE_STYLE = _NONE_STYLE_LABEL  # alias for backward compat
+
+
+def _build_user_text(
+    global_context: str,
+    style_preset: str,
+    shot_angle: str,
+    camera_move: str,
+    style_extra: str,
+    segment_hint: str = "",
+) -> str:
+    text = VISION_SYSTEM_PROMPT
+    if global_context.strip():
+        text += f"\n\nGlobal scene context provided by the director: {global_context.strip()}"
+    if segment_hint.strip():
+        text += f"\n\nSpecific instruction for this scene: {segment_hint.strip()}"
+
+    # Full style preset text (from STYLE_PRESETS dict) takes priority
+    preset_text = STYLE_PRESETS.get(style_preset, "")
+    if preset_text:
+        text += f"\n\n{preset_text}"
+    elif style_preset and style_preset != _NONE_STYLE:
+        # Unknown preset label — fall back to generic directive
+        text += f"\n\nVisual style: {style_preset}"
+
+    # Additional per-shot directives
+    extra_lines = []
+    if shot_angle and shot_angle != _NONE_STYLE:
+        extra_lines.append(f"- Shot angle: {shot_angle}")
+    if camera_move and camera_move != _NONE_STYLE:
+        extra_lines.append(f"- Camera movement: {camera_move}")
+    if style_extra.strip():
+        extra_lines.append(f"- Additional: {style_extra.strip()}")
+    if extra_lines:
+        text += "\n\nShot directives — incorporate these:\n" + "\n".join(extra_lines)
+    return text
+
+
 def _describe_image_sync(
     image_tensor: torch.Tensor,
     model_id: str,
@@ -145,13 +611,28 @@ def _describe_image_sync(
     global_context: str,
     temperature: float,
     max_tokens: int,
+    style_preset: str = _NONE_STYLE,
+    shot_angle: str = _NONE_STYLE,
+    camera_move: str = _NONE_STYLE,
+    style_extra: str = "",
+    mmproj_path: str = "",
+    segment_hint: str = "",
 ) -> str:
+    user_text = _build_user_text(global_context, style_preset, shot_angle, camera_move, style_extra, segment_hint)
+
+    # --- GGUF dispatch ---
+    gguf_file, is_gguf = _resolve_gguf_path(local_path)
+    if is_gguf:
+        if gguf_file:
+            mmproj = _find_mmproj(gguf_file, mmproj_path)
+            return _describe_image_gguf_sync(
+                image_tensor, gguf_file, mmproj, user_text, temperature, max_tokens
+            )
+        log.warning("[PromptWriter] GGUF mode detected but no .gguf file found in: %s — falling back to HuggingFace", local_path)
+
+    # --- Transformers dispatch ---
     processor, model = _load_vision_model(model_id, offline_mode, local_path)
     pil = _tensor_to_pil(image_tensor)
-
-    user_text = VISION_SYSTEM_PROMPT
-    if global_context.strip():
-        user_text += f"\n\nGlobal scene context provided by the director: {global_context.strip()}"
 
     messages = [{
         "role": "user",
@@ -242,6 +723,11 @@ async def handle_generate_prompts(request):
     local_path   = body.get("local_path", "")
     temperature  = float(body.get("temperature", 0.3))
     max_tokens   = int(body.get("max_tokens", 180))
+    style_preset = body.get("style_preset", _NONE_STYLE)
+    shot_angle   = body.get("shot_angle",   _NONE_STYLE)
+    camera_move  = body.get("camera_move",  _NONE_STYLE)
+    style_extra  = body.get("style_extra",  "")
+    mmproj_path  = body.get("mmproj_path",  "")
 
     model_id = VISION_MODELS.get(model_name, VISION_MODELS["Qwen2.5-VL-3B — Fast"])
 
@@ -255,18 +741,31 @@ async def handle_generate_prompts(request):
             prompts.append(seg.get("prompt", ""))
             continue
 
+        # Per-segment hint: dedicated hint field (never overwritten by generation).
+        # Falls back to empty string → only global_prompt is used.
+        segment_hint = seg.get("hint", "").strip()
+
         try:
             prompt = await loop.run_in_executor(
                 _executor,
                 _describe_image_sync,
                 tensor, model_id, offline_mode, local_path,
                 global_prompt, temperature, max_tokens,
+                style_preset, shot_angle, camera_move, style_extra,
+                mmproj_path, segment_hint,
             )
             prompts.append(prompt)
             log.info("[PromptWriter] Segment %d: %s…", i, prompt[:80])
         except Exception as e:
             log.error("[PromptWriter] Segment %d failed: %s", i, e)
+            # Unload before returning the error too
+            _unload_gguf_model()
+            _unload_vision_model()
             return web.json_response({"error": str(e)}, status=500)
+
+    # Always unload after generation to free VRAM / RAM
+    _unload_gguf_model()
+    _unload_vision_model()
 
     return web.json_response({"prompts": prompts, "model_used": model_name})
 
@@ -275,12 +774,21 @@ async def handle_generate_prompts(request):
 # Route registration
 # ---------------------------------------------------------------------------
 
+async def handle_style_presets(request):
+    """Return the list of available style preset names (for the JS dropdown)."""
+    from aiohttp import web
+    return web.json_response({"presets": list(STYLE_PRESETS.keys())})
+
+
 def register_routes() -> None:
     try:
         from server import PromptServer
         PromptServer.instance.routes.post(
             "/whatdreamscost/generate_prompts"
         )(handle_generate_prompts)
-        log.info("[PromptWriter] Route registered: POST /whatdreamscost/generate_prompts")
+        PromptServer.instance.routes.get(
+            "/whatdreamscost/style_presets"
+        )(handle_style_presets)
+        log.info("[PromptWriter] Routes registered.")
     except Exception as e:
-        log.warning("[PromptWriter] Could not register route: %s", e)
+        log.warning("[PromptWriter] Could not register routes: %s", e)

--- a/ltx_prompt_writer.py
+++ b/ltx_prompt_writer.py
@@ -1,0 +1,286 @@
+import asyncio
+import base64
+import gc
+import io as _io
+import json
+import logging
+import os
+from concurrent.futures import ThreadPoolExecutor
+
+import numpy as np
+import torch
+from PIL import Image
+
+import folder_paths
+
+log = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Model registry
+# ---------------------------------------------------------------------------
+
+VISION_MODELS = {
+    "Qwen2.5-VL-3B — Fast": "huihui-ai/Qwen2.5-VL-3B-Instruct-abliterated",
+    "Qwen2.5-VL-7B — Best quality": "prithivMLmods/Qwen2.5-VL-7B-Abliterated-Caption-it",
+}
+
+VISION_SYSTEM_PROMPT = (
+    "You are an expert cinematographer and prompt writer for LTX-Video 2.3, "
+    "a state-of-the-art AI video generation model.\n\n"
+    "Analyze the image and write a single scene description of 100-130 words "
+    "optimised for video generation.\n\n"
+    "Include:\n"
+    "- Subjects: physical appearance, clothing, pose, expression\n"
+    "- Environment: location, lighting, time of day, atmosphere, textures, dominant colours\n"
+    "- Camera: angle, distance, suggested movement (e.g. slow dolly, static wide, gentle pan)\n"
+    "- Motion: what is happening or about to happen in the scene\n\n"
+    "Rules:\n"
+    "- Write in present tense\n"
+    "- Be specific, cinematic, and visually dense\n"
+    "- Avoid negative phrasing — describe what IS present\n"
+    "- Output ONLY the scene description. No preamble, no labels, no metadata."
+)
+
+# ---------------------------------------------------------------------------
+# Model singleton (one vision model loaded at a time)
+# ---------------------------------------------------------------------------
+
+_executor = ThreadPoolExecutor(max_workers=1)
+_loaded_model_id: str | None = None
+_loaded_model = None
+_loaded_processor = None
+
+
+def _unload_vision_model() -> None:
+    global _loaded_model, _loaded_model_id, _loaded_processor
+    if _loaded_model is None:
+        return
+    try:
+        for param in _loaded_model.parameters():
+            param.data = torch.empty(0)
+    except Exception:
+        pass
+    _loaded_model = None
+    _loaded_processor = None
+    _loaded_model_id = None
+    for _ in range(3):
+        gc.collect()
+    if torch.cuda.is_available():
+        try:
+            torch.cuda.synchronize()
+            torch.cuda.empty_cache()
+            torch.cuda.ipc_collect()
+            torch.cuda.reset_peak_memory_stats()
+        except Exception:
+            pass
+    log.info("[PromptWriter] Vision model unloaded and VRAM freed.")
+
+
+def _load_vision_model(model_id: str, offline_mode: bool, local_path: str):
+    global _loaded_model, _loaded_model_id, _loaded_processor
+
+    if _loaded_model_id == model_id:
+        return _loaded_processor, _loaded_model
+
+    _unload_vision_model()
+
+    try:
+        import comfy.model_management as mm
+        mm.unload_all_models()
+        mm.soft_empty_cache()
+    except Exception:
+        pass
+
+    source = local_path.strip() if local_path.strip() else None
+
+    if not source or not os.path.exists(source):
+        try:
+            from huggingface_hub import snapshot_download
+            source = snapshot_download(
+                repo_id=model_id,
+                local_files_only=offline_mode,
+                ignore_patterns=["*.gguf"],
+            )
+        except Exception:
+            source = model_id
+
+    log.info("[PromptWriter] Loading vision model from: %s", source)
+
+    from transformers import Qwen2_5_VLForConditionalGeneration, AutoProcessor
+
+    processor = AutoProcessor.from_pretrained(source, local_files_only=offline_mode)
+
+    dtype = torch.bfloat16 if (torch.cuda.is_available() and torch.cuda.is_bf16_supported()) else torch.float16
+    model = Qwen2_5_VLForConditionalGeneration.from_pretrained(
+        source,
+        torch_dtype=dtype,
+        device_map="auto",
+        trust_remote_code=True,
+        local_files_only=offline_mode,
+    )
+    model.eval()
+    model.config.use_cache = True
+
+    _loaded_model = model
+    _loaded_model_id = model_id
+    _loaded_processor = processor
+    log.info("[PromptWriter] Vision model loaded: %s", model_id)
+    return processor, model
+
+
+# ---------------------------------------------------------------------------
+# Inference
+# ---------------------------------------------------------------------------
+
+def _tensor_to_pil(tensor: torch.Tensor) -> Image.Image:
+    arr = (tensor[0].cpu().numpy() * 255.0).clip(0, 255).astype(np.uint8)
+    return Image.fromarray(arr)
+
+
+def _describe_image_sync(
+    image_tensor: torch.Tensor,
+    model_id: str,
+    offline_mode: bool,
+    local_path: str,
+    global_context: str,
+    temperature: float,
+    max_tokens: int,
+) -> str:
+    processor, model = _load_vision_model(model_id, offline_mode, local_path)
+    pil = _tensor_to_pil(image_tensor)
+
+    user_text = VISION_SYSTEM_PROMPT
+    if global_context.strip():
+        user_text += f"\n\nGlobal scene context provided by the director: {global_context.strip()}"
+
+    messages = [{
+        "role": "user",
+        "content": [
+            {"type": "image", "image": pil},
+            {"type": "text", "text": user_text},
+        ],
+    }]
+
+    text = processor.apply_chat_template(messages, tokenize=False, add_generation_prompt=True)
+
+    # qwen_vl_utils is installed alongside Qwen2.5-VL (also used by LTX2EasyPrompt-LD)
+    try:
+        from qwen_vl_utils import process_vision_info
+        image_inputs, video_inputs = process_vision_info(messages)
+        inputs = processor(
+            text=[text],
+            images=image_inputs,
+            videos=video_inputs,
+            padding=True,
+            return_tensors="pt",
+        )
+    except ImportError:
+        # Fallback: pass PIL directly (works on newer transformers builds)
+        inputs = processor(text=[text], images=[pil], padding=True, return_tensors="pt")
+
+    inputs = inputs.to(model.device)
+
+    with torch.no_grad():
+        output_ids = model.generate(
+            **inputs,
+            max_new_tokens=max_tokens,
+            temperature=temperature if temperature > 0 else None,
+            top_p=0.9 if temperature > 0 else None,
+            do_sample=temperature > 0,
+        )
+
+    generated = output_ids[:, inputs["input_ids"].shape[1]:]
+    result = processor.batch_decode(
+        generated, skip_special_tokens=True, clean_up_tokenization_spaces=True
+    )[0]
+    return result.strip()
+
+
+def _load_image_tensor_from_seg(seg: dict) -> torch.Tensor | None:
+    image_file = seg.get("imageFile")
+    if image_file:
+        path = os.path.join(folder_paths.get_input_directory(), image_file)
+        if os.path.exists(path):
+            try:
+                pil = Image.open(path).convert("RGB")
+                arr = np.array(pil, dtype=np.float32) / 255.0
+                return torch.from_numpy(arr).unsqueeze(0)
+            except Exception:
+                pass
+
+    b64 = seg.get("imageB64", "")
+    if b64 and not b64.startswith("/view?"):
+        if "," in b64:
+            b64 = b64.split(",", 1)[1]
+        try:
+            img_bytes = base64.b64decode(b64)
+            pil = Image.open(_io.BytesIO(img_bytes)).convert("RGB")
+            arr = np.array(pil, dtype=np.float32) / 255.0
+            return torch.from_numpy(arr).unsqueeze(0)
+        except Exception:
+            pass
+
+    return None
+
+
+# ---------------------------------------------------------------------------
+# HTTP route
+# ---------------------------------------------------------------------------
+
+async def handle_generate_prompts(request):
+    from aiohttp import web
+
+    try:
+        body = await request.json()
+    except Exception as e:
+        return web.json_response({"error": f"Invalid JSON: {e}"}, status=400)
+
+    segments     = body.get("segments", [])
+    global_prompt = body.get("global_prompt", "")
+    model_name   = body.get("model_name", "Qwen2.5-VL-3B — Fast")
+    offline_mode = bool(body.get("offline_mode", False))
+    local_path   = body.get("local_path", "")
+    temperature  = float(body.get("temperature", 0.3))
+    max_tokens   = int(body.get("max_tokens", 180))
+
+    model_id = VISION_MODELS.get(model_name, VISION_MODELS["Qwen2.5-VL-3B — Fast"])
+
+    loop = asyncio.get_event_loop()
+    prompts: list[str] = []
+
+    for i, seg in enumerate(segments):
+        tensor = _load_image_tensor_from_seg(seg)
+        if tensor is None:
+            # Text-only segment — keep whatever prompt it already has
+            prompts.append(seg.get("prompt", ""))
+            continue
+
+        try:
+            prompt = await loop.run_in_executor(
+                _executor,
+                _describe_image_sync,
+                tensor, model_id, offline_mode, local_path,
+                global_prompt, temperature, max_tokens,
+            )
+            prompts.append(prompt)
+            log.info("[PromptWriter] Segment %d: %s…", i, prompt[:80])
+        except Exception as e:
+            log.error("[PromptWriter] Segment %d failed: %s", i, e)
+            return web.json_response({"error": str(e)}, status=500)
+
+    return web.json_response({"prompts": prompts, "model_used": model_name})
+
+
+# ---------------------------------------------------------------------------
+# Route registration
+# ---------------------------------------------------------------------------
+
+def register_routes() -> None:
+    try:
+        from server import PromptServer
+        PromptServer.instance.routes.post(
+            "/whatdreamscost/generate_prompts"
+        )(handle_generate_prompts)
+        log.info("[PromptWriter] Route registered: POST /whatdreamscost/generate_prompts")
+    except Exception as e:
+        log.warning("[PromptWriter] Could not register route: %s", e)

--- a/ltx_prompt_writer.py
+++ b/ltx_prompt_writer.py
@@ -47,6 +47,9 @@ VISION_SYSTEM_PROMPT = (
 # Each entry: "Preset name": "Full style instruction injected into the prompt."
 # Add new presets here — the JS dropdown is populated automatically via the
 # /whatdreamscost/style_presets endpoint; no JS edits needed.
+#
+# Style preset texts adapted from landon2022/LTX2EasyPrompt-LD
+# https://github.com/landon2022/LTX2EasyPrompt-LD
 # ---------------------------------------------------------------------------
 
 _NONE_STYLE_LABEL = "None — let VLM decide"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,17 @@
+# WhatDreamsCost-ComfyUI — Python dependencies
+#
+# Core dependencies (already present in any ComfyUI installation):
+#   torch, numpy, Pillow, aiohttp
+#
+# Optional — AI Prompt Writer (ltx_prompt_writer.py):
+#   All backends use lazy imports and degrade gracefully if not installed.
+#
+# GGUF backend (recommended — works with local .gguf models):
+#   Requires the llama-cpp_vllm custom node OR a manual install:
+#   pip install llama-cpp-python
+#
+# HuggingFace Transformers backend (Qwen2.5-VL):
+#   pip install transformers>=4.45.0
+#   pip install qwen-vl-utils   # optional, improves image handling
+#
+# If neither backend is installed, the ✨ Prompts button will return an error.


### PR DESCRIPTION
## Summary

Adds a self-contained AI prompt generation system directly into LTX Director — no external nodes required. Users can generate cinematic prompts from timeline images with a single click using a local model.

- **GGUF model support** via `llama-cpp-python`: point to a `.gguf` file or directory; `mmproj` auto-detected from the same folder
- **HuggingFace Transformers fallback** (Qwen2.5-VL-3B / 7B)
- **Qwen3.5-VL** supported with `Qwen35ChatHandler` + `enable_thinking=False`
- **Model unloaded from VRAM/RAM** after every generation
- **30+ cinematic style presets** with full instruction text — defined only in Python, JS dropdown auto-populated via HTTP endpoint
- **Per-segment Hint field**: persists across generations, guides VLM per image independently
- Shot Angle, Camera Movement, Extra Instruction controls in settings panel
- Settings menu dark theme fix + scrollable panel
- Standalone example workflow (no external node dependencies)
- It is never executed automatically in the workflow but via key prompts

## Dependencies

No new hard dependencies — all lazy imports, degrade gracefully if not installed. See `requirements.txt`.

## Attribution

Style preset texts adapted from [landon2022/LTX2EasyPrompt-LD](https://github.com/landon2022/LTX2EasyPrompt-LD) with attribution in source code.

Happy to adjust anything to fit the project's direction.


<img width="987" height="749" alt="screen uno" src="https://github.com/user-attachments/assets/47a66995-5b68-40f9-8c1f-406c4e5e0e3f" />

<img width="1041" height="791" alt="screen 2" src="https://github.com/user-attachments/assets/3a8d494e-c2d3-404b-b50d-e152c0b0ad39" />
