### PR TITLE
Clipmgt

### DIFF
--- a/js/ltx_director.js
+++ b/js/ltx_director.js
@@ -26,6 +26,20 @@ function hideWidget(w) {
 
 function clamp(v, min, max) { return Math.max(min, Math.min(max, v)); }
 
+// LTXV's video VAE decodes a latent of T frames into (T-1)*LTXV_TEMPORAL_STRIDE + 1 pixel frames,
+// so the only frame counts LTXV can output are 1, 9, 17, 25, ..., 185, 193, 201, ... — i.e. 8n+1.
+// Asking for an off-grid count (e.g. 192) silently rounds up to the next grid point (193), which
+// causes 1-frame video/audio mismatches that break seamless concatenation across clips. We snap
+// all image/text clip lengths to this grid so a per-clip batch render produces clips whose
+// rendered frame counts match the timeline frame counts exactly.
+const LTXV_TEMPORAL_STRIDE = 8;
+function snapToLTXVGrid(frames) {
+  const f = Math.max(1, Math.round(Number(frames) || 0));
+  if (f <= 1) return 1;
+  const n = Math.round((f - 1) / LTXV_TEMPORAL_STRIDE);
+  return Math.max(1, n * LTXV_TEMPORAL_STRIDE + 1);
+}
+
 // --- Modern Dark/Grey UI CSS (ComfyUI Match) ---
 const STYLES = `
   .pr-wrapper {
@@ -781,7 +795,9 @@ class TimelineEditor {
   // present each clip to Python as if it's the only thing on the timeline — sidesteps
   // _window_timeline entirely, so overlapping/adjacent clips can't leak in.
   buildIsolatedClipPayload(seg) {
-    const clipLen = Math.max(1, Math.round(seg.length));
+    // Snap to grid here too — if anything ever bypassed commitChanges with a non-grid length,
+    // the rendered video and audio frame counts must still match for seamless concatenation.
+    const clipLen = snapToLTXVGrid(seg.length);
     const clipStart = seg.start;
     const clipEnd = clipStart + seg.length;
 
@@ -1588,7 +1604,8 @@ class TimelineEditor {
   async handleImageUpload(files, targetFrameStart = null, explicitLength = null) {
     const frameRate = this.getFrameRate();
     const durationFrames = this.getDurationFrames();
-    const newLength = explicitLength !== null ? explicitLength : frameRate * 1; // Default to 1 second long
+    // Snap to LTXV grid so the new clip is renderable as a self-contained unit.
+    const newLength = snapToLTXVGrid(explicitLength !== null ? explicitLength : frameRate * 1);
 
     for (let file of files) {
       if (!file.type.startsWith("image/")) continue;
@@ -2975,6 +2992,15 @@ class TimelineEditor {
 
   // --- Backend Data Sync ---
   commitChanges(skipRender = false) {
+    // Snap image/text clip lengths to LTXV's 8n+1 frame grid so each per-clip render
+    // produces video and audio of identical frame count. Audio segments are untouched —
+    // they're sliced per-clip, not rendered. See snapToLTXVGrid above for rationale.
+    for (const seg of this.timeline.segments) {
+      if (seg.type === "audio") continue;
+      const snapped = snapToLTXVGrid(seg.length);
+      if (snapped !== seg.length) seg.length = snapped;
+    }
+
     // Auto-size duration to the content extent before anything reads it.
     this.syncDurationToContent();
 
@@ -3854,7 +3880,7 @@ class TimelineEditor {
 
   addTextSegmentFreeSpace() {
     const frameRate = this.getFrameRate();
-    const newLength = Math.max(1, frameRate); // 1 second default
+    const newLength = snapToLTXVGrid(frameRate); // ~1 second, snapped to LTXV grid
     const sorted = [...this.timeline.segments].sort((a, b) => a.start - b.start);
     let newStart = 0;
     for (const seg of sorted) {

--- a/js/ltx_director.js
+++ b/js/ltx_director.js
@@ -718,8 +718,177 @@ class TimelineEditor {
     return parseInt((this.durationFramesWidget && this.durationFramesWidget.value > 0) ? this.durationFramesWidget.value : 24, 10);
   }
 
+  // Furthest end-frame across all clips (image + audio). Drives duration_frames so
+  // the timeline length always matches its content — users no longer set this manually.
+  getContentDurationFrames() {
+    let furthest = 0;
+    for (const seg of this.timeline.segments || []) {
+      furthest = Math.max(furthest, Math.ceil(seg.start + seg.length));
+    }
+    for (const seg of this.timeline.audioSegments || []) {
+      furthest = Math.max(furthest, Math.ceil(seg.start + seg.length));
+    }
+    return Math.max(1, furthest);
+  }
+
+  // Sync duration_frames / duration_seconds to match the current timeline content.
+  syncDurationToContent() {
+    const frames = this.getContentDurationFrames();
+    if (this.durationFramesWidget && this.durationFramesWidget.value !== frames) {
+      this.durationFramesWidget.value = frames;
+    }
+    if (this.durationSecondsWidget) {
+      const secs = parseFloat((frames / this.getFrameRate()).toFixed(3));
+      if (this.durationSecondsWidget.value !== secs) {
+        this.durationSecondsWidget.value = secs;
+      }
+    }
+  }
+
   getFrameRate() {
     return parseInt((this.frameRateWidget && this.frameRateWidget.value > 0) ? this.frameRateWidget.value : 24, 10);
+  }
+
+  // Render-window helpers. `window_end_frames === 0` means "to the end".
+  // Returns { start, end, active } in pixel-space frames, clipped to duration.
+  getWindow() {
+    const duration = this.getDurationFrames();
+    const startW = this.node.widgets.find(w => w.name === "window_start_frames");
+    const endW = this.node.widgets.find(w => w.name === "window_end_frames");
+    const rawStart = startW ? Math.max(0, parseInt(startW.value || 0, 10)) : 0;
+    const rawEnd = endW ? Math.max(0, parseInt(endW.value || 0, 10)) : 0;
+    const start = Math.min(rawStart, duration);
+    const end = rawEnd > 0 ? Math.min(rawEnd, duration) : duration;
+    const active = (rawStart > 0) || (rawEnd > 0 && rawEnd < duration);
+    return { start, end: Math.max(end, start + 1), active };
+  }
+
+  setWindow(start, end) {
+    const startW = this.node.widgets.find(w => w.name === "window_start_frames");
+    const endW = this.node.widgets.find(w => w.name === "window_end_frames");
+    if (startW) startW.value = Math.max(0, Math.round(start));
+    if (endW) endW.value = Math.max(0, Math.round(end));
+    if (window.app && window.app.graph) window.app.graph.setDirtyCanvas(true, true);
+    this.render();
+  }
+
+  clearWindow() {
+    this.setWindow(0, 0);
+  }
+
+  // Build the JSON-safe form of a single clip + its overlapping audio, with all
+  // start positions shifted so the clip begins at frame 0. Used by renderAllClips to
+  // present each clip to Python as if it's the only thing on the timeline — sidesteps
+  // _window_timeline entirely, so overlapping/adjacent clips can't leak in.
+  buildIsolatedClipPayload(seg) {
+    const clipLen = Math.max(1, Math.round(seg.length));
+    const clipStart = seg.start;
+    const clipEnd = clipStart + seg.length;
+
+    // Strip the in-memory image object before serializing.
+    const cleanSeg = { ...seg };
+    delete cleanSeg.imgObj;
+    cleanSeg.start = 0;
+    cleanSeg.length = clipLen;
+
+    // Mirror the Python _window_timeline behavior: only front-clip the audio.
+    // Trailing samples past clipEnd are clipped downstream by total_samples in
+    // _build_combined_audio, which prevents ~0.04s of silence at the end vs. the
+    // single-clip codepath.
+    const audio = [];
+    for (const aseg of (this.timeline.audioSegments || [])) {
+      const aStart = aseg.start;
+      const aEnd = aseg.start + aseg.length;
+      if (aEnd <= clipStart || aStart >= clipEnd) continue;
+      const clipFront = Math.max(0, clipStart - aStart);
+      const newLen = aseg.length - clipFront;
+      if (newLen <= 0) continue;
+      audio.push({
+        ...aseg,
+        trimStart: (aseg.trimStart || 0) + clipFront,
+        length: newLen,
+        start: Math.max(0, aStart - clipStart),
+      });
+    }
+
+    return {
+      clipLen,
+      timelineJson: JSON.stringify({ segments: [cleanSeg], audioSegments: audio }),
+      prompt: seg.prompt || "",
+      guideStrength: (seg.type === "text") ? "" : (seg.guideStrength !== undefined ? seg.guideStrength : 1.0).toFixed(2),
+    };
+  }
+
+  // Queue one render per clip, each in true isolation: the timeline_data widget is
+  // temporarily replaced with a single-clip JSON so Python sees only that one clip
+  // (and any audio overlapping it). Window widgets are forced to 0 so the Python-side
+  // windowing logic is bypassed entirely. All widgets are restored when done.
+  async renderAllClips() {
+    if (this._renderingAll) return;
+
+    const segs = [...(this.timeline.segments || [])].sort((a, b) => a.start - b.start);
+    if (segs.length === 0) {
+      alert("No clips to render.");
+      return;
+    }
+
+    const names = [
+      "timeline_data", "local_prompts", "segment_lengths", "guide_strength",
+      "duration_frames", "duration_seconds", "window_start_frames", "window_end_frames",
+    ];
+    const widgets = {};
+    const orig = {};
+    for (const n of names) {
+      const w = this.node.widgets.find(x => x.name === n);
+      if (w) {
+        widgets[n] = w;
+        orig[n] = w.value;
+      }
+    }
+
+    if (!window.confirm(`Queue ${segs.length} isolated render${segs.length === 1 ? "" : "s"}, one per clip?`)) {
+      return;
+    }
+
+    const origBtnHtml = this.renderAllBtn ? this.renderAllBtn.innerHTML : null;
+    this._renderingAll = true;
+    if (this.renderAllBtn) this.renderAllBtn.disabled = true;
+
+    try {
+      const fps = this.getFrameRate();
+      for (let i = 0; i < segs.length; i++) {
+        const seg = segs[i];
+        const payload = this.buildIsolatedClipPayload(seg);
+
+        if (widgets.timeline_data)       widgets.timeline_data.value       = payload.timelineJson;
+        if (widgets.local_prompts)       widgets.local_prompts.value       = payload.prompt;
+        if (widgets.segment_lengths)     widgets.segment_lengths.value     = String(payload.clipLen);
+        if (widgets.guide_strength)      widgets.guide_strength.value      = payload.guideStrength;
+        if (widgets.duration_frames)     widgets.duration_frames.value     = payload.clipLen;
+        if (widgets.duration_seconds)    widgets.duration_seconds.value    = parseFloat((payload.clipLen / fps).toFixed(3));
+        if (widgets.window_start_frames) widgets.window_start_frames.value = 0;
+        if (widgets.window_end_frames)   widgets.window_end_frames.value   = 0;
+
+        if (this.renderAllBtn) {
+          this.renderAllBtn.innerHTML = `Queuing ${i + 1}/${segs.length}…`;
+        }
+
+        await app.queuePrompt(0, 1);
+      }
+    } catch (err) {
+      console.error("[LTXDirector] Render All Clips failed:", err);
+      alert("Render All Clips failed: " + (err && err.message ? err.message : err));
+    } finally {
+      for (const n in orig) {
+        if (widgets[n]) widgets[n].value = orig[n];
+      }
+      this._renderingAll = false;
+      if (this.renderAllBtn) {
+        this.renderAllBtn.disabled = false;
+        if (origBtnHtml !== null) this.renderAllBtn.innerHTML = origBtnHtml;
+      }
+      this.render();
+    }
   }
 
   // Grow the timeline duration to fit `requiredFrames` if it is currently shorter.
@@ -883,12 +1052,19 @@ class TimelineEditor {
     deleteBtn.innerHTML = `${ICONS.trash} Delete`;
     deleteBtn.addEventListener("click", () => this.deleteSelectedSegment());
 
+    this.renderAllBtn = document.createElement("button");
+    this.renderAllBtn.className = "pr-btn";
+    this.renderAllBtn.innerHTML = `${ICONS.play} Render All Clips`;
+    this.renderAllBtn.title = "Queue one render per clip, each windowed to that clip's range.";
+    this.renderAllBtn.addEventListener("click", () => this.renderAllClips());
+
     actionGroup.appendChild(this.fileInput);
     actionGroup.appendChild(this.audioFileInput);
     actionGroup.appendChild(uploadBtn);
     actionGroup.appendChild(addTextBtn);
     actionGroup.appendChild(uploadAudioBtn);
     actionGroup.appendChild(deleteBtn);
+    actionGroup.appendChild(this.renderAllBtn);
     toolbar.appendChild(actionGroup);
 
     const rightGroup = document.createElement("div");
@@ -1639,24 +1815,8 @@ class TimelineEditor {
   }
 
   updateWidgetVisibility() {
-    const mode = this.displayModeWidget ? this.displayModeWidget.value : "seconds";
-
-    if (this.durationFramesWidget) {
-      // Always visible regardless of display mode
-      this.durationFramesWidget.type = "INT";
-      if (!this.durationFramesWidget.options) this.durationFramesWidget.options = {};
-      this.durationFramesWidget.options.hidden = false;
-      this.durationFramesWidget.hidden = false;
-      delete this.durationFramesWidget.computeSize;
-    }
-    if (this.durationSecondsWidget) {
-      // Always visible regardless of display mode
-      this.durationSecondsWidget.type = "FLOAT";
-      if (!this.durationSecondsWidget.options) this.durationSecondsWidget.options = {};
-      this.durationSecondsWidget.options.hidden = false;
-      this.durationSecondsWidget.hidden = false;
-      delete this.durationSecondsWidget.computeSize;
-    }
+    // duration_frames / duration_seconds are auto-derived from the timeline content
+    // (see syncDurationToContent) and stay hidden — they're managed in hideSettingsWidgets.
 
     // Force node resize and redraw deferred to next tick
     setTimeout(() => {
@@ -2099,6 +2259,62 @@ class TimelineEditor {
         this.ctx.textBaseline = "middle";
         this.ctx.fillText("+", gap.centerX, gap.centerY + 1);
       }
+    }
+
+    // --- Render-window shadow overlay ---
+    // When window_start_frames / window_end_frames slice the timeline,
+    // shade everything OUTSIDE the window so the user can see what will actually render.
+    const win = this.getWindow();
+    if (win.active) {
+      const winStartX = (win.start / totalFrames) * width;
+      const winEndX = (win.end / totalFrames) * width;
+      const tracksH = this.blockHeight + this.audioTrackHeight;
+
+      this.ctx.fillStyle = "rgba(0, 0, 0, 0.55)";
+      if (winStartX > 0) this.ctx.fillRect(0, RULER_HEIGHT, winStartX, tracksH);
+      if (winEndX < width) this.ctx.fillRect(winEndX, RULER_HEIGHT, width - winEndX, tracksH);
+
+      // Tinted ruler stripe inside the window so it pops
+      this.ctx.fillStyle = "rgba(120, 200, 255, 0.18)";
+      this.ctx.fillRect(winStartX, 0, winEndX - winStartX, RULER_HEIGHT);
+
+      // Bracket markers at each end
+      this.ctx.save();
+      this.ctx.strokeStyle = "rgba(120, 200, 255, 0.95)";
+      this.ctx.lineWidth = 2;
+      this.ctx.beginPath();
+      // Left bracket
+      this.ctx.moveTo(winStartX + 5, 2);
+      this.ctx.lineTo(winStartX, 2);
+      this.ctx.lineTo(winStartX, RULER_HEIGHT + tracksH - 2);
+      this.ctx.lineTo(winStartX + 5, RULER_HEIGHT + tracksH - 2);
+      // Right bracket
+      this.ctx.moveTo(winEndX - 5, 2);
+      this.ctx.lineTo(winEndX, 2);
+      this.ctx.lineTo(winEndX, RULER_HEIGHT + tracksH - 2);
+      this.ctx.lineTo(winEndX - 5, RULER_HEIGHT + tracksH - 2);
+      this.ctx.stroke();
+      this.ctx.restore();
+
+      // Range label centered inside the window so the user can confirm what renders.
+      const winFrames = Math.max(0, Math.round(win.end - win.start));
+      let label;
+      try {
+        label = `Render window: ${this.formatTime(win.start, true)}–${this.formatTime(win.end, true)} (${winFrames}f)`;
+      } catch (e) {
+        label = `Render window: ${Math.round(win.start)}–${Math.round(win.end)} (${winFrames}f)`;
+      }
+      this.ctx.save();
+      this.ctx.font = "11px sans-serif";
+      this.ctx.textAlign = "center";
+      this.ctx.textBaseline = "top";
+      const labelX = Math.min(Math.max((winStartX + winEndX) / 2, 60), width - 60);
+      const labelW = this.ctx.measureText(label).width + 10;
+      this.ctx.fillStyle = "rgba(20, 30, 45, 0.85)";
+      this.ctx.fillRect(labelX - labelW / 2, RULER_HEIGHT + 3, labelW, 16);
+      this.ctx.fillStyle = "rgba(170, 220, 255, 1)";
+      this.ctx.fillText(label, labelX, RULER_HEIGHT + 5);
+      this.ctx.restore();
     }
 
     // --- Out-of-duration shadow overlay ---
@@ -2759,6 +2975,9 @@ class TimelineEditor {
 
   // --- Backend Data Sync ---
   commitChanges(skipRender = false) {
+    // Auto-size duration to the content extent before anything reads it.
+    this.syncDurationToContent();
+
     let sortedSegments = [...this.timeline.segments].sort((a, b) => a.start - b.start);
     let contiguousLengths = [];
     let contiguousPrompts = [];
@@ -3037,6 +3256,56 @@ class TimelineEditor {
       menu.appendChild(pasteReplaceBtn);
     }
 
+    // --- Render-window helpers (set start/end to this clip's boundaries) ---
+    // Available on every track (image, text, and audio) so any clip edge can
+    // become a window boundary.
+    {
+      const segStart = Math.round(seg.start);
+      const segEnd = Math.round(seg.start + seg.length);
+
+      const winStartBtn = document.createElement("button");
+      winStartBtn.className = "pr-gap-menu-btn";
+      winStartBtn.innerHTML = `Window: Start at this clip`;
+      winStartBtn.onclick = () => {
+        const { end } = this.getWindow();
+        const newEnd = end > segStart ? end : 0; // 0 = "to the end"
+        this.setWindow(segStart, newEnd);
+        this.dismissContextMenu();
+      };
+      menu.appendChild(winStartBtn);
+
+      const winEndBtn = document.createElement("button");
+      winEndBtn.className = "pr-gap-menu-btn";
+      winEndBtn.innerHTML = `Window: End after this clip`;
+      winEndBtn.onclick = () => {
+        const { start } = this.getWindow();
+        const newStart = start < segEnd ? start : 0;
+        this.setWindow(newStart, segEnd);
+        this.dismissContextMenu();
+      };
+      menu.appendChild(winEndBtn);
+
+      const winOnlyBtn = document.createElement("button");
+      winOnlyBtn.className = "pr-gap-menu-btn";
+      winOnlyBtn.innerHTML = `Window: Only this clip`;
+      winOnlyBtn.onclick = () => {
+        this.setWindow(segStart, segEnd);
+        this.dismissContextMenu();
+      };
+      menu.appendChild(winOnlyBtn);
+
+      if (this.getWindow().active) {
+        const winClearBtn = document.createElement("button");
+        winClearBtn.className = "pr-gap-menu-btn";
+        winClearBtn.innerHTML = `Window: Clear (render all)`;
+        winClearBtn.onclick = () => {
+          this.clearWindow();
+          this.dismissContextMenu();
+        };
+        menu.appendChild(winClearBtn);
+      }
+    }
+
     const delBtn = document.createElement("button");
     delBtn.className = "pr-gap-menu-btn";
     delBtn.innerHTML = `Delete`;
@@ -3209,7 +3478,7 @@ class TimelineEditor {
   // --- Settings Menu ---
   // Widgets that are managed by the settings menu (hidden from node by default).
   get _settingsWidgetNames() {
-    return ["display_mode", "epsilon", "divisible_by", "img_compression"];
+    return ["display_mode", "epsilon", "divisible_by", "img_compression", "duration_frames", "duration_seconds"];
   }
 
   // Hide all settings widgets on the node (called on init).

--- a/ltx_director.py
+++ b/ltx_director.py
@@ -370,6 +370,112 @@ def _encode_relay(model, clip, latent, global_prompt, local_prompts, segment_len
     return patched, conditioning
 
 
+def _window_timeline(tdata: dict, win_start: int, win_end: int, isolate: bool = False):
+    """Slice a timeline dict to the pixel-space window [win_start, win_end).
+
+    Mirrors the JS contiguous-prompt/length packer (gaps absorbed into the
+    adjacent segment, last segment padded to reach the cutoff) but applied to
+    the window instead of the full duration. All emitted segment starts are
+    shifted into window-local coordinates (window start -> 0).
+
+    When `isolate=True`, any segment whose start is *before* win_start is dropped
+    even if it overlaps into the window — so a clip that bleeds in from before
+    the window can't sneak its guide image into the render. Use this when you
+    want a clip to render as if it's the only thing on the timeline.
+
+    Returns:
+        prompts:        list[str] for the windowed segments, in order.
+        lengths:        list[int] matching prompts, summing to win_end-win_start.
+        img_strengths:  list[float] for non-"text" segments in the window
+                        (mirrors the JS guide_strength serialisation).
+        segments:       list[dict] of windowed segments (start shifted, length
+                        clipped). Used to rebuild timeline_data for downstream
+                        guide-image extraction.
+        audio_segments: list[dict] of windowed audio segments (start shifted,
+                        trimStart pushed forward by any front-clip, length
+                        clipped on both ends).
+    """
+    segments = sorted(tdata.get("segments", []), key=lambda s: int(s.get("start", 0)))
+
+    prompts: list = []
+    lengths: list = []
+    img_strengths: list = []
+    out_segments: list = []
+
+    pending_gap = 0
+    cursor = win_start  # in original frame space; gaps measured against this
+
+    for seg in segments:
+        # Use round() not int() — drag-and-drop in the JS timeline can leave starts
+        # as floats like 191.6 that int() would truncate to 191, which then sneaks
+        # past the `seg_start >= win_end` check and bleeds one frame into the window.
+        seg_start = int(round(float(seg.get("start", 0))))
+        seg_len = int(round(float(seg.get("length", 0))))
+        seg_end = seg_start + seg_len
+
+        if seg_end <= win_start:
+            continue
+        if seg_start >= win_end:
+            break
+        # Isolation: drop clips that overlap into the window from before — they're
+        # not "the clip this window is for".
+        if isolate and seg_start < win_start:
+            continue
+
+        clipped_start = max(seg_start, win_start)
+        clipped_end = min(seg_end, win_end)
+        clipped_length = clipped_end - clipped_start
+
+        if clipped_start > cursor:
+            gap = clipped_start - cursor
+            if lengths:
+                lengths[-1] += gap
+            else:
+                pending_gap += gap
+
+        lengths.append(clipped_length + pending_gap)
+        prompts.append(seg.get("prompt", ""))
+        pending_gap = 0
+        cursor = max(cursor, seg_end)
+
+        if seg.get("type", "image") != "text":
+            img_strengths.append(float(seg.get("guideStrength", 1.0)))
+
+        shifted = dict(seg)
+        shifted["start"] = clipped_start - win_start
+        shifted["length"] = clipped_length
+        out_segments.append(shifted)
+
+    clamped_cursor = min(cursor, win_end)
+    if lengths and clamped_cursor < win_end:
+        lengths[-1] += win_end - clamped_cursor
+
+    # Audio segments — keep anything that intersects the window, push front-clip
+    # into trimStart so we still play the correct portion of the source clip.
+    # We deliberately do NOT back-clip at win_end: _build_combined_audio caps the
+    # output at `total_samples` (derived from ltxv_length, which is duration_frames + 1).
+    # Back-clipping here would shorten the audio by one LTXV padding frame and produce
+    # ~0.04s of trailing silence that the unwindowed single-clip path doesn't have.
+    out_audio: list = []
+    for aseg in tdata.get("audioSegments", []):
+        a_start = float(aseg.get("start", 0))
+        a_len = float(aseg.get("length", 0))
+        a_end = a_start + a_len
+        if a_end <= win_start or a_start >= win_end:
+            continue
+        clip_front = max(0.0, win_start - a_start)
+        new_len = a_len - clip_front
+        if new_len <= 0:
+            continue
+        shifted = dict(aseg)
+        shifted["trimStart"] = float(aseg.get("trimStart", 0)) + clip_front
+        shifted["length"] = new_len
+        shifted["start"] = max(0.0, a_start - win_start)
+        out_audio.append(shifted)
+
+    return prompts, lengths, img_strengths, out_segments, out_audio
+
+
 class LTXDirector(io.ComfyNode):
     """WYSIWYG timeline variant — segments and lengths come from a visual editor in the node UI."""
 
@@ -456,6 +562,29 @@ class LTXDirector(io.ComfyNode):
                     "img_compression", default=18, min=0, max=100, step=1, optional=True,
                     tooltip="H.264 CRF compression to apply to each guide image. 0 = no compression, higher = more artefacts.",
                 ),
+                io.Int.Input(
+                    "window_start_frames", default=0, min=0, max=10000, step=1, optional=True,
+                    tooltip="Render only the timeline slice starting at this pixel-space frame. 0 = from the beginning. "
+                            "Use this (or right-click a clip → Window) to render a sub-section and avoid running out of VRAM on long timelines.",
+                ),
+                io.Int.Input(
+                    "window_end_frames", default=0, min=0, max=10000, step=1, optional=True,
+                    tooltip="Render only the timeline slice ending at this pixel-space frame (exclusive). 0 = to the end (no windowing). "
+                            "Shrinks the auto-generated latent so only the windowed frames are sampled.",
+                ),
+                io.Boolean.Input(
+                    "isolate_clips", default=False, optional=True,
+                    tooltip="When ON, the window only includes clips whose start is inside it — clips that bleed in from before "
+                            "the window are dropped. Use this to render a single clip as if it were the only thing on the timeline "
+                            "(prevents an adjacent clip's guide image from leaking into the render).",
+                ),
+                io.Boolean.Input(
+                    "anchor_clip_end", default=False, optional=True,
+                    tooltip="When ON, the first guide image is also inserted at the last frame of the latent. "
+                            "Stops LTXV from drifting into a distorted version of the start image at the end of the clip — "
+                            "the model has to interpolate between the image and itself, producing coherent motion. "
+                            "Most useful in combination with isolate_clips.",
+                ),
             ],
             outputs=[
                 io.Model.Output(display_name="model"),
@@ -474,7 +603,79 @@ class LTXDirector(io.ComfyNode):
                 frame_rate=24, display_mode="seconds",
                 custom_width=768, custom_height=512, resize_method="maintain aspect ratio",
                 divisible_by=32, img_compression=0, audio_vae=None, optional_latent=None,
-                use_custom_audio=False) -> io.NodeOutput:
+                use_custom_audio=False, window_start_frames=0, window_end_frames=0,
+                isolate_clips=False, anchor_clip_end=False) -> io.NodeOutput:
+
+        # --- Optional timeline windowing ---
+        # Render only the slice [window_start_frames, window_end_frames) of the timeline.
+        # This is the key to rendering long timelines without running out of VRAM: when no
+        # latent is connected, duration_frames drives the auto-generated latent's temporal
+        # size, so shrinking it here means only the windowed frames are ever sampled.
+        # local_prompts, segment_lengths, guide_strength and timeline_data are all re-derived
+        # from the windowed view, so the rest of execute() is unchanged afterwards.
+        win_start = max(0, int(window_start_frames))
+        win_end_raw = int(window_end_frames)
+        win_end = win_end_raw if win_end_raw > 0 else duration_frames
+        win_end = min(win_end, duration_frames)
+        if win_end <= win_start:
+            win_end = win_start + 1
+        # `isolate_clips` forces windowing to run even with no explicit window, so a
+        # single clip at the start of the timeline can still be rendered alone.
+        windowing_active = (
+            (win_start > 0)
+            or (win_end_raw > 0 and win_end_raw < duration_frames)
+            or bool(isolate_clips)
+        )
+
+        if windowing_active:
+            if optional_latent is not None:
+                # An external latent fixes the sampled frame count, so windowing the prompts
+                # alone won't reduce VRAM. Warn rather than silently slice someone else's latent.
+                log.warning(
+                    "[PromptRelay] window active but optional_latent is connected — the latent's "
+                    "frame count is fixed upstream, so windowing will NOT reduce memory. "
+                    "Disconnect optional_latent to let the Director size the latent to the window."
+                )
+
+            try:
+                tdata_full = json.loads(timeline_data) if timeline_data else None
+            except Exception as e:
+                log.warning("[PromptRelay] window: timeline_data not parseable, skipping window: %s", e)
+                tdata_full = None
+
+            if tdata_full is not None:
+                (win_prompts, win_lengths, win_img_strengths,
+                 win_segments, win_audio_segs) = _window_timeline(
+                    tdata_full, win_start, win_end, isolate=bool(isolate_clips)
+                )
+
+                if not win_prompts:
+                    raise ValueError(
+                        f"LTXDirector window [{win_start}, {win_end}) contains no prompt segments. "
+                        "Adjust window_start_frames / window_end_frames."
+                    )
+
+                local_prompts = " | ".join(win_prompts)
+                segment_lengths = ",".join(str(int(l)) for l in win_lengths)
+                guide_strength = ",".join(f"{s:.2f}" for s in win_img_strengths)
+
+                # Re-serialize timeline_data with shifted segments/audio for downstream consumers.
+                tdata_full["segments"] = win_segments
+                tdata_full["audioSegments"] = win_audio_segs
+                timeline_data = json.dumps(tdata_full)
+                duration_frames = win_end - win_start
+                log.info(
+                    "[PromptRelay] window active%s: [%d, %d) -> %d frames, %d prompt segs, %d image segs, %d audio segs",
+                    " (isolated)" if isolate_clips else "",
+                    win_start, win_end, duration_frames, len(win_prompts),
+                    sum(1 for s in win_segments if s.get("imageFile") or s.get("imageB64")),
+                    len(win_audio_segs),
+                )
+                for i, a in enumerate(win_audio_segs):
+                    log.info(
+                        "[PromptRelay] window audio[%d]: start=%.2f length=%.2f trimStart=%.2f",
+                        i, float(a.get("start", 0)), float(a.get("length", 0)), float(a.get("trimStart", 0)),
+                    )
 
         # --- Build guide_data from image segments FIRST (to derive output dimensions) ---
         guide_data = {"images": [], "insert_frames": [], "strengths": [], "frame_rate": frame_rate}
@@ -557,7 +758,9 @@ class LTXDirector(io.ComfyNode):
         if optional_latent is None:
             latent_w = max(32, (derived_w // 32) * 32)
             latent_h = max(32, (derived_h // 32) * 32)
-            # LTXV temporal: ((length - 1) // 8) + 1 latent frames; invert to get pixel frames -> length
+            # LTXV temporal: ((length - 1) // 8) + 1 latent frames; invert to get pixel frames -> length.
+            # LTXDirectorGuide writes guides in-place via replace_latent_frames, so the latent doesn't
+            # grow and we don't need to compensate for an appended-keyframe suffix here.
             latent_t = ((ltxv_length - 1) // 8) + 1
             samples = torch.zeros(
                 [1, 128, latent_t, latent_h // 32, latent_w // 32],
@@ -570,6 +773,55 @@ class LTXDirector(io.ComfyNode):
             )
         else:
             latent = optional_latent
+
+        # --- Clamp guide insert frames into the latent's safe range ---
+        # LTXVAddGuide computes latent_idx = (frame_idx + 7) // 8 and asserts
+        # latent_idx + t.shape[2] <= latent_length. For single-image guides
+        # t.shape[2] == 1, so the largest safe frame_idx is 8 * (latent_length - 1).
+        # When duration_frames is not a multiple of 8 (very common with windowing
+        # or arbitrary clip boundaries), images placed in the last sub-stride
+        # of pixel frames would otherwise overflow the latent.
+        try:
+            latent_length = int(latent["samples"].shape[2])
+            max_safe_frame = max(0, 8 * (latent_length - 1))
+            for i, f in enumerate(guide_data["insert_frames"]):
+                if f > max_safe_frame:
+                    log.info(
+                        "[PromptRelay] Clamping guide image %d insert frame %d -> %d (latent_length=%d)",
+                        i + 1, f, max_safe_frame, latent_length,
+                    )
+                    guide_data["insert_frames"][i] = max_safe_frame
+        except Exception as e:
+            log.warning("[PromptRelay] Could not clamp guide insert_frames: %s", e)
+
+        # --- Anchor the clip's end with the start image ---
+        # LTXV with only a frame-0 guide drifts freely toward the end of the latent,
+        # often producing a distorted echo of the start image. Duplicating the first
+        # guide at the last safe frame anchors both ends so the model has to interpolate
+        # between the image and itself instead of inventing content.
+        if anchor_clip_end and guide_data["images"]:
+            try:
+                end_frame = int(max_safe_frame)
+                # Don't double-up if something already anchors the end (within one stride).
+                already_anchored = any(
+                    abs(int(f) - end_frame) < 8 for f in guide_data["insert_frames"]
+                )
+                if not already_anchored:
+                    guide_data["images"].append(guide_data["images"][0])
+                    guide_data["insert_frames"].append(end_frame)
+                    guide_data["strengths"].append(float(guide_data["strengths"][0]))
+                    log.info(
+                        "[PromptRelay] anchor_clip_end: duplicated guide image 1 at frame %d "
+                        "(latent_length=%d, strength=%.2f)",
+                        end_frame, latent_length, guide_data["strengths"][-1],
+                    )
+                else:
+                    log.info(
+                        "[PromptRelay] anchor_clip_end: end frame %d already has a guide nearby, skipping.",
+                        end_frame,
+                    )
+            except Exception as e:
+                log.warning("[PromptRelay] Could not anchor clip end: %s", e)
 
         patched, conditioning = _encode_relay(
             model, clip, latent, global_prompt, local_prompts, segment_lengths, epsilon,
@@ -616,6 +868,24 @@ class LTXDirector(io.ComfyNode):
                                 "waveform": waveform,
                                 "sample_rate": audio_out["sample_rate"],
                             })
+
+                        # Diagnostic: encoded latent shape vs the "ideal" empty-latent shape for
+                        # ltxv_length frames. If the encoded latent has fewer T positions than the
+                        # empty one would, the downstream sampler/decoder will produce shorter audio.
+                        try:
+                            inner = getattr(audio_vae, "first_stage_model", audio_vae)
+                            ideal_T = inner.num_of_latents_from_frames(ltxv_length, float(frame_rate))
+                            log.info(
+                                "[PromptRelay] custom audio: waveform=%s, encoded latent=%s, "
+                                "ideal latent T for %d frames = %d",
+                                tuple(waveform.shape), tuple(latent_samples.shape),
+                                ltxv_length, ideal_T,
+                            )
+                        except Exception as _:
+                            log.info(
+                                "[PromptRelay] custom audio: waveform=%s, encoded latent=%s",
+                                tuple(waveform.shape), tuple(latent_samples.shape),
+                            )
                         
                         if latent_samples.numel() == 0:
                             raise ValueError("Encoded audio latent is empty (0 elements).")

--- a/ltx_director.py
+++ b/ltx_director.py
@@ -828,7 +828,12 @@ class LTXDirector(io.ComfyNode):
         )
 
         # --- Build Audio Output ---
-        audio_out = _build_combined_audio(timeline_data, ltxv_length, float(frame_rate))
+        # Size the combined waveform by `duration_frames`, NOT `ltxv_length` (which is +1 due to
+        # the LTXV pixel-frame grid). Otherwise each isolated/windowed render pulls one extra
+        # source frame of audio past the clip's nominal end, and when the user concatenates
+        # back-to-back clips that 1-frame overflow shows up as an overlap at adjacent boundaries
+        # and as a skip when there's any small placement gap.
+        audio_out = _build_combined_audio(timeline_data, duration_frames, float(frame_rate))
 
         # --- Audio Latent Generation ---
         audio_latent = {}

--- a/ltx_director_guide.py
+++ b/ltx_director_guide.py
@@ -83,8 +83,15 @@ class LTXDirectorGuide(LTXVAddGuide):
                 f"Guide image {idx + 1}: conditioning frames exceed the length of the latent sequence."
             )
 
-            positive, negative, latent_image, noise_mask = cls.append_keyframe(
-                positive, negative, frame_idx, latent_image, noise_mask, t, strength, scale_factors,
+            # Write the guide into the existing latent in-place rather than appending it.
+            # append_keyframe + LTXVCropGuides is the canonical LTXV pattern, but it grows the
+            # latent by 1 frame per guide and requires a downstream crop node — when the crop is
+            # missing (as in most LTXDirector workflows) the appended guide gets VAE-decoded as
+            # 8 extra pixel frames of "distorted start image" at the tail. replace_latent_frames
+            # keeps the latent the size the Director sized it to, so the decoded video is exactly
+            # the requested length with no trailing echo.
+            latent_image, noise_mask = cls.replace_latent_frames(
+                latent_image, noise_mask, t, latent_idx, strength,
             )
 
         return io.NodeOutput(positive, negative, {"samples": latent_image, "noise_mask": noise_mask})


### PR DESCRIPTION
Added per-clip isolation, audio path and LTXV grid snapping to enable cleanly rendering a timeline as separate clips. This significantly changes the way the LTX director node works. It enables rendering a long timeline on low-VRAM systems, but this can't be mixed with clips consisting of multiple prompts.