### PR TITLE
Fix arbitrary file read/write in LoadVideoUI HTTP routes

### DIFF
--- a/load_video_ui.py
+++ b/load_video_ui.py
@@ -7,11 +7,29 @@ from server import PromptServer
 from aiohttp import web
 import comfy.utils
 
-# Custom API route to serve video files from anywhere on the user's system for the frontend preview
+# Media file extensions this preview route is allowed to serve. Restricting to
+# media types prevents the route from being abused to read arbitrary files
+# (e.g. SSH keys, .env, config, source) off the server's filesystem.
+_ALLOWED_PREVIEW_EXTS = {
+    ".mp4", ".mov", ".mkv", ".webm", ".avi", ".m4v", ".mpg", ".mpeg", ".wmv", ".flv", ".gif",
+    ".mp3", ".wav", ".flac", ".ogg", ".m4a", ".aac", ".opus",
+}
+
+# Custom API route to serve user-selected video files for the frontend preview.
+# The feature intentionally allows previewing media chosen by absolute path, but
+# the path is normalised and the extension is allow-listed so this cannot be used
+# as a wildcard arbitrary-file-read primitive.
 @PromptServer.instance.routes.get("/video_ui_custom_view")
 async def custom_view(request):
-    file_path = request.query.get("filename", "")
-    if os.path.exists(file_path) and os.path.isfile(file_path):
+    raw = request.query.get("filename", "")
+    if not raw:
+        return web.Response(status=400, text="Missing filename")
+
+    # Resolve symlinks/.. and compare against an extension allow-list.
+    file_path = os.path.realpath(raw)
+    if os.path.splitext(file_path)[1].lower() not in _ALLOWED_PREVIEW_EXTS:
+        return web.Response(status=403, text="File type not allowed")
+    if os.path.isfile(file_path):
         return web.FileResponse(file_path)
     return web.Response(status=404, text="File not found")
 
@@ -21,11 +39,30 @@ async def upload_chunk(request):
     post = await request.post()
     file = post.get("file")
     filename = post.get("filename")
-    chunk_index = int(post.get("chunk_index"))
-    total_chunks = int(post.get("total_chunks"))
+
+    if file is None or not filename:
+        return web.Response(status=400, text="Missing file or filename")
+
+    try:
+        chunk_index = int(post.get("chunk_index"))
+        total_chunks = int(post.get("total_chunks"))
+    except (TypeError, ValueError):
+        return web.Response(status=400, text="Invalid chunk metadata")
 
     upload_dir = folder_paths.get_input_directory()
-    file_path = os.path.join(upload_dir, filename)
+
+    # Strip any directory components so a malicious/crafted filename (e.g.
+    # "..\..\autorun.bat" or an absolute path) cannot escape the input directory.
+    safe_name = os.path.basename(filename)
+    if not safe_name or safe_name in (".", ".."):
+        return web.Response(status=400, text="Invalid filename")
+
+    file_path = os.path.join(upload_dir, safe_name)
+
+    # Defence in depth: confirm the resolved path stays inside the input directory.
+    real_upload_dir = os.path.realpath(upload_dir)
+    if os.path.commonpath([real_upload_dir, os.path.realpath(file_path)]) != real_upload_dir:
+        return web.Response(status=400, text="Invalid filename")
 
     # Append to file if it's not the first chunk, otherwise write new
     mode = "ab" if chunk_index > 0 else "wb"
@@ -33,7 +70,7 @@ async def upload_chunk(request):
         f.write(file.file.read())
 
     if chunk_index == total_chunks - 1:
-        return web.json_response({"name": filename})
+        return web.json_response({"name": safe_name})
     return web.json_response({"status": "ok"})
 
 


### PR DESCRIPTION
## Summary

Fixes two unauthenticated file-access vulnerabilities in the HTTP routes that `LoadVideoUI` registers on the ComfyUI server at import time. Because they are registered at import (not when a node is placed on the canvas), they go live as soon as the pack is installed, and ComfyUI's server has no auth by default.

### 🔴 Arbitrary file read — `/video_ui_custom_view`

The route served any file on disk by absolute path straight from the `filename` query param with no validation:

```python
file_path = request.query.get("filename", "")
if os.path.exists(file_path) and os.path.isfile(file_path):
    return web.FileResponse(file_path)
```

`GET /video_ui_custom_view?filename=C:\Users\you\.ssh\id_rsa` (or `/etc/passwd`) returned the file contents — a full arbitrary-file-read primitive over anything the ComfyUI process can read.

**Fix:** normalise the path with `os.path.realpath` and restrict served files to a media extension allow-list. This preserves the intended feature (previewing user-selected media by absolute path) while blocking disclosure of credentials, config, and source files.

### 🟠 Path traversal / arbitrary file write — `/video_ui_upload_chunk`

The route wrote a client-supplied `filename` into the input directory via `os.path.join`:

```python
file_path = os.path.join(upload_dir, filename)
```

A crafted filename (`..\..\autorun.bat`, or an absolute path which `os.path.join` honours) escapes the input directory, enabling arbitrary file writes.

**Fix:** strip directory components with `os.path.basename`, confirm the resolved path stays inside the input directory via `os.path.commonpath`, validate the chunk metadata, and return the sanitised name to the client. The existing client-side flow is unaffected (it already sends a flat, sanitised basename — this just enforces it server-side, where it belongs).

## Notes

These routes remain unauthenticated (a ComfyUI-wide design constraint), so they're still reachable via CSRF from a logged-in user's browser or by anything that can reach the server. This PR removes the dangerous *capabilities*; deployments exposing ComfyUI beyond localhost should still treat the server as untrusted-network-facing.

No behavioural change to legitimate use of the node.
