### PR TITLE
Feat/timeline serialization

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -6,6 +6,7 @@ from .load_audio_ui import LoadAudioUI
 from .load_video_ui import LoadVideoUI
 from .ltx_director import LTXDirector
 from .ltx_director_guide import LTXDirectorGuide
+from . import ltx_director_bundle  # registers /ltx_director/{save,load}_bundle routes
 from comfy_api.latest import ComfyExtension, io
 from typing_extensions import override
 

--- a/js/ltx_director.js
+++ b/js/ltx_director.js
@@ -643,6 +643,9 @@ class TimelineEditor {
       this.selectedIndex = 0;
     }
     this.updateUIFromSelection();
+    // Restore persisted global-prompt visibility before commitChanges re-serializes,
+    // otherwise the default-hidden state would overwrite the saved flag on reload.
+    this._restoreGlobalPromptVisibility();
     this.commitChanges(true);
     // Hide settings widgets by default to reduce node clutter.
     // Deferred so all widget types are finalized before we touch them.
@@ -2801,12 +2804,17 @@ class TimelineEditor {
       contiguousLengths[contiguousLengths.length - 1] += durationFrames - clampedCursor;
     }
 
+    // Persist the global-prompt enabled state alongside the timeline so it survives
+    // graph reloads (onConfigure) — its visibility is not part of ComfyUI's native
+    // widget serialization.
+    const gpWidget = this.node.widgets?.find(w => w.name === "global_prompt");
     const toSave = {
       segments: sortedSegments.map(s => {
         const { imgObj, ...rest } = s;
         return rest;
       }),
-      audioSegments: (this.timeline.audioSegments || []).map(s => ({ ...s }))
+      audioSegments: (this.timeline.audioSegments || []).map(s => ({ ...s })),
+      globalPromptVisible: !(gpWidget?.options && gpWidget.options.hidden)
     };
 
     const jsonStr = JSON.stringify(toSave);
@@ -3494,29 +3502,7 @@ class TimelineEditor {
       cb.checked = !(globalPromptWidget.options && globalPromptWidget.options.hidden);
       cb.style.cursor = "pointer";
       cb.addEventListener("change", () => {
-        const isVisible = cb.checked;
-        if (!globalPromptWidget.options) globalPromptWidget.options = {};
-        globalPromptWidget.options.hidden = !isVisible;
-
-        if (isVisible) {
-          delete globalPromptWidget.computeSize;
-          globalPromptWidget.hidden = false;
-          if (globalPromptWidget.element) globalPromptWidget.element.style.display = "";
-        } else {
-          globalPromptWidget.computeSize = () => [0, 0];
-          globalPromptWidget.hidden = true;
-          if (globalPromptWidget.element) globalPromptWidget.element.style.display = "none";
-        }
-
-        // Force refresh via display mode double-toggle trick
-        if (this.displayModeWidget) {
-          const origVal = this.displayModeWidget.value;
-          const otherVal = origVal === "frames" ? "seconds" : "frames";
-          this.displayModeWidget.value = otherVal;
-          if (this.displayModeWidget.callback) this.displayModeWidget.callback(otherVal);
-          this.displayModeWidget.value = origVal;
-          if (this.displayModeWidget.callback) this.displayModeWidget.callback(origVal);
-        }
+        this._setGlobalPromptVisible(cb.checked);
       });
       menu.appendChild(this._makeSettingRow("Use Global Prompt", cb));
     }
@@ -3566,6 +3552,44 @@ class TimelineEditor {
   dismissSettingsMenu() {
     if (this._settingsMenu) { this._settingsMenu.remove(); this._settingsMenu = null; }
     if (this._settingsDismisser) { document.removeEventListener("mousedown", this._settingsDismisser); this._settingsDismisser = null; }
+  }
+
+  // --- Global Prompt Visibility (persisted across reloads) ---
+
+  // Show or hide the global_prompt widget. Extracted so the settings checkbox and the
+  // restore path share one source of truth for the visibility logic.
+  _setGlobalPromptVisible(visible) {
+    const gp = this.node.widgets?.find(w => w.name === "global_prompt");
+    if (!gp) return;
+    if (!gp.options) gp.options = {};
+    gp.options.hidden = !visible;
+    if (visible) {
+      delete gp.computeSize;
+      gp.hidden = false;
+      if (gp.element) gp.element.style.display = "";
+    } else {
+      gp.computeSize = () => [0, 0];
+      gp.hidden = true;
+      if (gp.element) gp.element.style.display = "none";
+    }
+    // Force ComfyUI to re-measure the node via the display-mode double-toggle trick.
+    if (this.displayModeWidget) {
+      const origVal = this.displayModeWidget.value;
+      const otherVal = origVal === "frames" ? "seconds" : "frames";
+      this.displayModeWidget.value = otherVal;
+      if (this.displayModeWidget.callback) this.displayModeWidget.callback(otherVal);
+      this.displayModeWidget.value = origVal;
+      if (this.displayModeWidget.callback) this.displayModeWidget.callback(origVal);
+    }
+  }
+
+  // Restore the global-prompt enabled state from the flag persisted in timeline_data.
+  // Used by the editor constructor and onConfigure so the state survives graph reloads.
+  _restoreGlobalPromptVisibility() {
+    try {
+      const raw = JSON.parse(this.timelineDataWidget?.value || "{}");
+      if (raw.globalPromptVisible !== undefined) this._setGlobalPromptVisible(!!raw.globalPromptVisible);
+    } catch (e) { }
   }
 
 
@@ -3858,6 +3882,7 @@ app.registerExtension({
         setTimeout(() => {
           if (this._timelineEditor) {
             this._timelineEditor.timeline = parseInitial(this._timelineEditor.timelineDataWidget?.value);
+            this._timelineEditor._restoreGlobalPromptVisibility();
             this._timelineEditor.loadImages();
             this._timelineEditor.selectionType = "image";
             this._timelineEditor.selectedIndex = clamp(

--- a/js/ltx_director.js
+++ b/js/ltx_director.js
@@ -3507,6 +3507,56 @@ class TimelineEditor {
       menu.appendChild(this._makeSettingRow("Use Global Prompt", cb));
     }
 
+    // --- Save / Load Timeline (file + bundle) ---
+    const fileDivider = document.createElement("hr");
+    fileDivider.className = "pr-settings-divider";
+    menu.appendChild(fileDivider);
+
+    const makeFileRow = (label, onSave, onLoad) => {
+      const row = document.createElement("div");
+      row.className = "pr-settings-row";
+      const lbl = document.createElement("span");
+      lbl.className = "pr-settings-label";
+      lbl.textContent = label;
+      const btnWrap = document.createElement("div");
+      btnWrap.style.display = "flex";
+      btnWrap.style.gap = "6px";
+      const saveBtn = document.createElement("button");
+      saveBtn.className = "pr-settings-toggle-btn";
+      saveBtn.style.width = "auto";
+      saveBtn.textContent = "Save";
+      saveBtn.addEventListener("click", onSave);
+      const loadBtn = document.createElement("button");
+      loadBtn.className = "pr-settings-toggle-btn";
+      loadBtn.style.width = "auto";
+      loadBtn.textContent = "Load";
+      loadBtn.addEventListener("click", onLoad);
+      btnWrap.appendChild(saveBtn);
+      btnWrap.appendChild(loadBtn);
+      row.appendChild(lbl);
+      row.appendChild(btnWrap);
+      return row;
+    };
+
+    const pickFile = (accept, handler) => {
+      const fi = document.createElement("input");
+      fi.type = "file";
+      fi.accept = accept;
+      fi.addEventListener("change", (ev) => {
+        if (ev.target.files?.[0]) handler(ev.target.files[0]);
+        this.dismissSettingsMenu();
+      });
+      fi.click();
+    };
+
+    menu.appendChild(makeFileRow("Timeline File",
+      () => this.saveTimelineToFile(),
+      () => pickFile(".json,application/json", (f) => this.loadTimelineFromFile(f))));
+
+    menu.appendChild(makeFileRow("Bundle (zip)",
+      () => this.saveBundleToFile(),
+      () => pickFile(".zip,application/zip", (f) => this.loadBundleFromFile(f))));
+
 
     // --- Show/Hide on Node Toggle ---
     const toggleBtn = document.createElement("button");
@@ -3590,6 +3640,156 @@ class TimelineEditor {
       const raw = JSON.parse(this.timelineDataWidget?.value || "{}");
       if (raw.globalPromptVisible !== undefined) this._setGlobalPromptVisible(!!raw.globalPromptVisible);
     } catch (e) { }
+  }
+
+  // --- Timeline Serialization (save/load file + bundle) ---
+
+  // Build the serializable payload: the full timeline plus all node-level settings.
+  // Derived widgets (local_prompts/segment_lengths/guide_strength) are intentionally
+  // omitted — commitChanges() recomputes them on load.
+  _buildSerializationPayload() {
+    this.commitChanges(true); // ensure timeline_data is current before reading it
+    const node = this.node;
+    const getVal = (n) => node.widgets?.find(w => w.name === n)?.value;
+    const gpWidget = node.widgets?.find(w => w.name === "global_prompt");
+    let timeline = { segments: [], audioSegments: [] };
+    try { timeline = JSON.parse(this.timelineDataWidget?.value || "{}"); } catch (e) { }
+    return {
+      format: "ltx-director-timeline",
+      version: 1,
+      timeline,
+      settings: {
+        global_prompt: gpWidget?.value || "",
+        global_prompt_visible: !(gpWidget?.options && gpWidget.options.hidden),
+        duration_frames: getVal("duration_frames"),
+        duration_seconds: getVal("duration_seconds"),
+        frame_rate: getVal("frame_rate"),
+        display_mode: getVal("display_mode"),
+        epsilon: getVal("epsilon"),
+        divisible_by: getVal("divisible_by"),
+        img_compression: getVal("img_compression"),
+        custom_width: getVal("custom_width"),
+        custom_height: getVal("custom_height"),
+        resize_method: getVal("resize_method"),
+        use_custom_audio: getVal("use_custom_audio"),
+      },
+    };
+  }
+
+  _downloadBlob(blob, filename) {
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = filename;
+    a.click();
+    setTimeout(() => URL.revokeObjectURL(url), 0);
+  }
+
+  // Apply a parsed payload to the node: settings, global prompt, then re-hydrate the
+  // timeline (mirrors the onConfigure restore path). Shared by file-load and bundle-load.
+  _applyLoadedPayload(payload) {
+    if (!payload || payload.format !== "ltx-director-timeline") {
+      console.warn("[PromptRelay] Not an LTX Director timeline file; ignoring.");
+      return false;
+    }
+    const node = this.node;
+    const s = payload.settings || {};
+    const setVal = (n, v) => {
+      if (v === undefined) return;
+      const w = node.widgets?.find(x => x.name === n);
+      if (!w) return;
+      w.value = v;
+      if (w.callback) { try { w.callback(v, app.canvas, node, null, null); } catch (e) { } }
+    };
+    setVal("duration_frames", s.duration_frames);
+    setVal("duration_seconds", s.duration_seconds);
+    setVal("frame_rate", s.frame_rate);
+    setVal("display_mode", s.display_mode);
+    setVal("epsilon", s.epsilon);
+    setVal("divisible_by", s.divisible_by);
+    setVal("img_compression", s.img_compression);
+    setVal("custom_width", s.custom_width);
+    setVal("custom_height", s.custom_height);
+    setVal("resize_method", s.resize_method);
+    setVal("use_custom_audio", s.use_custom_audio);
+
+    const gp = node.widgets?.find(w => w.name === "global_prompt");
+    if (gp && s.global_prompt !== undefined) gp.value = s.global_prompt;
+    if (s.global_prompt_visible !== undefined) this._setGlobalPromptVisible(!!s.global_prompt_visible);
+
+    const timeline = payload.timeline || { segments: [], audioSegments: [] };
+    const json = JSON.stringify(timeline);
+    if (this.timelineDataWidget) this.timelineDataWidget.value = json;
+    this.timeline = parseInitial(json);
+
+    // Rebuild any missing image preview URLs (e.g. after a bundle re-paths imageFile).
+    for (const seg of this.timeline.segments) {
+      if (seg.imageFile && !seg.imageB64) {
+        const idx = seg.imageFile.lastIndexOf("/");
+        const sub = idx >= 0 ? seg.imageFile.slice(0, idx) : "";
+        const fname = idx >= 0 ? seg.imageFile.slice(idx + 1) : seg.imageFile;
+        seg.imageB64 = api.apiURL(`/view?filename=${encodeURIComponent(fname)}&type=input&subfolder=${encodeURIComponent(sub)}`);
+      }
+    }
+
+    this.loadImages();
+    this.selectionType = "image";
+    this.selectedIndex = this.timeline.segments.length ? 0 : -1;
+    this.updateUIFromSelection();
+    this.commitChanges();
+    this.render();
+    return true;
+  }
+
+  // --- Timeline File (lightweight JSON; media referenced by filename) ---
+  saveTimelineToFile() {
+    const payload = this._buildSerializationPayload();
+    this._downloadBlob(
+      new Blob([JSON.stringify(payload, null, 2)], { type: "application/json" }),
+      "ltx_director_timeline.json"
+    );
+  }
+
+  loadTimelineFromFile(file) {
+    const reader = new FileReader();
+    reader.onload = () => {
+      let payload;
+      try { payload = JSON.parse(reader.result); }
+      catch (e) { console.error("[PromptRelay] Invalid timeline JSON", e); return; }
+      this._applyLoadedPayload(payload);
+    };
+    reader.readAsText(file);
+  }
+
+  // --- Bundle (portable zip; media packaged + staged into input/<bundleName>/) ---
+  async saveBundleToFile() {
+    const payload = this._buildSerializationPayload();
+    payload.bundleName = "ltx_director_bundle";
+    try {
+      const resp = await api.fetchApi("/ltx_director/save_bundle", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      if (resp.status !== 200) { console.error("[PromptRelay] save_bundle failed", resp.status); return; }
+      const blob = await resp.blob();
+      this._downloadBlob(blob, "ltx_director_bundle.zip");
+    } catch (err) {
+      console.error("[PromptRelay] save bundle error", err);
+    }
+  }
+
+  async loadBundleFromFile(file) {
+    try {
+      const body = new FormData();
+      body.append("bundle", file);
+      const resp = await api.fetchApi("/ltx_director/load_bundle", { method: "POST", body });
+      if (resp.status !== 200) { console.error("[PromptRelay] load_bundle failed", resp.status); return; }
+      const data = await resp.json();
+      this._applyLoadedPayload(data.payload);
+    } catch (err) {
+      console.error("[PromptRelay] load bundle error", err);
+    }
   }
 
 

--- a/ltx_director_bundle.py
+++ b/ltx_director_bundle.py
@@ -1,0 +1,178 @@
+"""HTTP routes backing the LTX Director timeline *bundle* (portable zip) feature.
+
+A bundle packages a timeline's JSON payload together with the actual media files it
+references, so a timeline can be backed up or shared and restored on a fresh install.
+
+Two routes:
+  POST /ltx_director/save_bundle  -> zip {timeline.json + media/<rel>} for download
+  POST /ltx_director/load_bundle  -> extract media into input/<bundleName>/ and return
+                                     the manifest with media paths re-pointed there
+
+Security note: the load route writes files from an *uploaded* zip into ComfyUI's input
+directory. It therefore mirrors the hardened-route patterns already used in
+load_video_ui.py — every extracted path is basename/relative-sanitised, checked against
+an extension allow-list, and asserted to resolve *inside* input/<bundleName>/ (zip-slip
+defence). The save route likewise refuses to read any media reference that escapes the
+input directory.
+"""
+
+import io
+import os
+import re
+import json
+import zipfile
+
+import folder_paths
+from server import PromptServer
+from aiohttp import web
+
+# Media types allowed inside a bundle. Restricting extraction to known media
+# extensions prevents a crafted bundle from dropping executable/script files
+# (e.g. .py, .bat, .dll) into the ComfyUI input directory.
+_BUNDLE_MEDIA_EXTS = {
+    ".png", ".jpg", ".jpeg", ".webp", ".gif", ".bmp", ".tiff", ".tif",
+    ".mp3", ".wav", ".flac", ".ogg", ".m4a", ".aac", ".opus",
+}
+
+# Anything outside this set is collapsed to "_" when deriving a bundle subfolder name.
+_BUNDLE_NAME_RE = re.compile(r"[^A-Za-z0-9._-]")
+
+
+def _safe_bundle_name(raw):
+    """Reduce an uploaded filename to a single safe path segment (no separators)."""
+    base = os.path.basename(raw or "")
+    if base.lower().endswith(".zip"):
+        base = base[:-4]
+    base = _BUNDLE_NAME_RE.sub("_", base).strip("._")
+    return base or "bundle"
+
+
+def _input_dir():
+    return os.path.realpath(folder_paths.get_input_directory())
+
+
+def _contained(root, path):
+    """True iff ``path`` resolves to a location inside ``root`` (symlinks/.. resolved)."""
+    try:
+        root = os.path.realpath(root)
+        target = os.path.realpath(path)
+        return os.path.commonpath([root, target]) == root
+    except ValueError:
+        # Different drives / mixed absolute-relative on Windows -> not contained.
+        return False
+
+
+def _collect_media_refs(timeline):
+    """Ordered, de-duplicated input-dir-relative media references used by a timeline."""
+    refs = []
+    for seg in (timeline.get("segments") or []):
+        f = seg.get("imageFile")
+        if f:
+            refs.append(f)
+    for seg in (timeline.get("audioSegments") or []):
+        f = seg.get("audioFile")
+        if f:
+            refs.append(f)
+    seen = set()
+    out = []
+    for r in refs:
+        if r not in seen:
+            seen.add(r)
+            out.append(r)
+    return out
+
+
+@PromptServer.instance.routes.post("/ltx_director/save_bundle")
+async def save_bundle(request):
+    try:
+        payload = await request.json()
+    except Exception:
+        return web.Response(status=400, text="Invalid JSON body")
+
+    timeline = payload.get("timeline") or {}
+    input_dir = _input_dir()
+
+    buf = io.BytesIO()
+    missing = []
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr("timeline.json", json.dumps(payload, indent=2))
+        for rel in _collect_media_refs(timeline):
+            # `rel` is an input-dir-relative path; reject anything that escapes it.
+            src = os.path.join(input_dir, rel)
+            if not _contained(input_dir, src) or not os.path.isfile(src):
+                missing.append(rel)
+                continue
+            arcname = "media/" + rel.replace("\\", "/")
+            zf.write(src, arcname)
+
+    buf.seek(0)
+    name = _safe_bundle_name(payload.get("bundleName") or "ltx_director_bundle")
+    headers = {"Content-Disposition": 'attachment; filename="%s.zip"' % name}
+    if missing:
+        # Surface skipped (missing/out-of-tree) media without failing the download.
+        headers["X-Bundle-Missing"] = str(len(missing))
+    return web.Response(body=buf.read(), content_type="application/zip", headers=headers)
+
+
+@PromptServer.instance.routes.post("/ltx_director/load_bundle")
+async def load_bundle(request):
+    post = await request.post()
+    field = post.get("bundle")
+    if field is None:
+        return web.Response(status=400, text="Missing bundle file")
+
+    bundle_name = _safe_bundle_name(getattr(field, "filename", "") or "bundle.zip")
+
+    real_dest_root = os.path.realpath(os.path.join(_input_dir(), bundle_name))
+    # Defence in depth: the sanitised name must keep us inside the input directory.
+    if not _contained(_input_dir(), real_dest_root):
+        return web.Response(status=400, text="Invalid bundle name")
+
+    try:
+        data = field.file.read()
+        zf = zipfile.ZipFile(io.BytesIO(data))
+    except Exception:
+        return web.Response(status=400, text="Invalid zip file")
+
+    try:
+        manifest = json.loads(zf.read("timeline.json").decode("utf-8"))
+    except Exception:
+        return web.Response(status=400, text="Bundle missing timeline.json")
+
+    os.makedirs(real_dest_root, exist_ok=True)
+
+    staged = []
+    for info in zf.infolist():
+        if info.is_dir():
+            continue
+        name = info.filename.replace("\\", "/")
+        if not name.startswith("media/"):
+            continue
+        rel = name[len("media/"):]
+        if not rel:
+            continue
+        # Zip-slip defence: resolve under dest root and confirm containment.
+        out_path = os.path.join(real_dest_root, *[p for p in rel.split("/") if p])
+        if not _contained(real_dest_root, out_path):
+            continue
+        if os.path.splitext(out_path)[1].lower() not in _BUNDLE_MEDIA_EXTS:
+            continue
+        os.makedirs(os.path.dirname(out_path), exist_ok=True)
+        # Always write (create-or-overwrite) per the staging contract.
+        with open(out_path, "wb") as fh:
+            fh.write(zf.read(info))
+        staged.append(rel)
+
+    # Re-point media references to input/<bundleName>/<rel> and drop the stale /view
+    # URL so the editor rebuilds it for the staged subfolder.
+    timeline = manifest.get("timeline") or {}
+    for seg in (timeline.get("segments") or []):
+        if seg.get("imageFile"):
+            seg["imageFile"] = "%s/%s" % (bundle_name, seg["imageFile"].replace("\\", "/"))
+            seg.pop("imageB64", None)
+    for seg in (timeline.get("audioSegments") or []):
+        if seg.get("audioFile"):
+            seg["audioFile"] = "%s/%s" % (bundle_name, seg["audioFile"].replace("\\", "/"))
+
+    manifest["bundleName"] = bundle_name
+    return web.json_response({"payload": manifest, "staged": staged, "bundleName": bundle_name})


### PR DESCRIPTION
## Timeline save/load — Timeline File (JSON) + portable Bundle (zip)

Serialize an LTX Director timeline (and all node settings) to a file and restore it
later or in another graph. Two options from the settings (gear) menu:

- **Timeline File** — a `.json` with the full timeline + node settings (global prompt
  & visibility, durations, frame rate, display mode, epsilon, divisible_by,
  img_compression, custom dims, resize method, use_custom_audio). Media is referenced
  by filename — lightweight, not self-contained.
- **Bundle (zip)** — packages the JSON *and* the media; loading stages it into
  `input/<bundleName>/` and re-points the clips, so it's fully portable.

### Notes
- Restore reuses the existing `onConfigure` re-hydrate path; derived widgets
  (`local_prompts`/`segment_lengths`/`guide_strength`) are recomputed on load, not
  stored. No `execute()` changes.
- New `ltx_director_bundle.py` adds `POST /ltx_director/{save,load}_bundle`, following
  the hardened patterns in `load_video_ui.py`: input-dir containment on save; sanitised
  bundle name, media-extension allow-list, and per-entry zip-slip containment on load.
- Frontend is vanilla JS (no build step); only new dep is stdlib `zipfile`.
- **Stacked on the global-prompt visibility-persistence fix** (separate PR) — please
  merge that first; this then shows serialization-only changes once rebased.

### Testing (manual, in ComfyUI)
Save/Load a mixed timeline (image+text+audio) onto a fresh node and confirm full
restore. Save Bundle, move the original `input/` media, Load Bundle, and confirm media
stages into `input/<bundleName>/` and a run reads it. Negative: foreign file →
warning; zip with `media/../../evil.png` or a disallowed extension → rejected.