### PR TITLE
feat: video import into the LTX Director timeline

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -6,6 +6,7 @@ from .load_audio_ui import LoadAudioUI
 from .load_video_ui import LoadVideoUI
 from .ltx_director import LTXDirector
 from .ltx_director_guide import LTXDirectorGuide
+from . import ltx_director_video  # registers /ltx_director/extract_video_frames route
 from comfy_api.latest import ComfyExtension, io
 from typing_extensions import override
 

--- a/js/ltx_director.js
+++ b/js/ltx_director.js
@@ -1654,7 +1654,7 @@ class TimelineEditor {
         const subfolder = uploadData.subfolder || "";
         const videoFile = subfolder ? subfolder + "/" + uploadData.name : uploadData.name;
 
-        // 2. Extract guide frames via backend route
+        // 2. Extract guide frames (and audio) via backend route
         const extractResp = await api.fetchApi("/ltx_director/extract_video_frames", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
@@ -1664,7 +1664,7 @@ class TimelineEditor {
           console.error("[PromptRelay] Frame extraction failed:", extractResp.status, await extractResp.text());
           continue;
         }
-        const { frames, totalPixelFrames } = await extractResp.json();
+        const { frames, totalPixelFrames, audioFile } = await extractResp.json();
         if (!frames || frames.length === 0) continue;
 
         const newLength = totalPixelFrames;
@@ -1721,6 +1721,24 @@ class TimelineEditor {
         });
 
         this.timeline.segments.push(seg);
+
+        // 6. If the backend extracted audio, add a matching audio segment
+        if (audioFile) {
+          const audioSeg = {
+            id: Date.now().toString() + Math.random().toString(36).substr(2, 5),
+            type: "audio",
+            start: newStart,
+            length: newLength,
+            trimStart: 0,
+            audioDurationFrames: newLength,
+            audioFile,
+            fileName: audioFile.split("/").pop(),
+            waveformPeaks: [],
+          };
+          this.timeline.audioSegments.push(audioSeg);
+          this.timeline.audioSegments.sort((a, b) => a.start - b.start);
+        }
+
         this.commitChanges();
 
       } catch (err) {
@@ -3251,6 +3269,20 @@ class TimelineEditor {
         fi.click();
       };
       menu.appendChild(imgBtn);
+
+      const vidBtn = document.createElement("button");
+      vidBtn.className = "pr-gap-menu-btn";
+      vidBtn.innerHTML = `${ICONS.play} Video Segment`;
+      vidBtn.onclick = () => {
+        this.dismissContextMenu();
+        const fi = document.createElement("input");
+        fi.type = "file"; fi.accept = "video/*";
+        fi.addEventListener("change", (ev) => {
+          if (ev.target.files?.[0]) this.handleVideoUpload([ev.target.files[0]], gap.frameStart);
+        });
+        fi.click();
+      };
+      menu.appendChild(vidBtn);
     }
 
     document.body.appendChild(menu);

--- a/js/ltx_director.js
+++ b/js/ltx_director.js
@@ -1722,18 +1722,48 @@ class TimelineEditor {
 
         this.timeline.segments.push(seg);
 
-        // 6. If the backend extracted audio, add a matching audio segment
+        // 6. If the backend extracted audio, decode it for peaks then add a matching audio segment
         if (audioFile) {
+          const audioFilename = audioFile.split("/").pop();
+          const audioSubfolder = audioFile.includes("/") ? audioFile.substring(0, audioFile.lastIndexOf("/")) : "";
+          const audioViewUrl = api.apiURL(`/view?filename=${encodeURIComponent(audioFilename)}&type=input&subfolder=${encodeURIComponent(audioSubfolder)}`);
+
+          let waveformPeaks = [];
+          let audioDurationFrames = newLength;
+
+          try {
+            const audioResp = await fetch(audioViewUrl);
+            const arrayBuffer = await audioResp.arrayBuffer();
+            const audioCtx = new (window.AudioContext || window.webkitAudioContext)();
+            const audioBuffer = await audioCtx.decodeAudioData(arrayBuffer);
+            audioDurationFrames = Math.max(1, Math.ceil(audioBuffer.duration * frameRate));
+
+            // Compute 200-point peak waveform — same as handleAudioUpload
+            const channelData = audioBuffer.getChannelData(0);
+            const numPeaks = 200;
+            const step = Math.max(1, Math.floor(channelData.length / numPeaks));
+            for (let i = 0; i < numPeaks; i++) {
+              let max = 0;
+              for (let j = 0; j < step; j++) {
+                const val = Math.abs(channelData[i * step + j] || 0);
+                if (val > max) max = val;
+              }
+              waveformPeaks.push(max);
+            }
+          } catch (e) {
+            console.warn("[PromptRelay] Could not decode audio for waveform peaks:", e);
+          }
+
           const audioSeg = {
             id: Date.now().toString() + Math.random().toString(36).substr(2, 5),
             type: "audio",
             start: newStart,
             length: newLength,
             trimStart: 0,
-            audioDurationFrames: newLength,
+            audioDurationFrames,
             audioFile,
-            fileName: audioFile.split("/").pop(),
-            waveformPeaks: [],
+            fileName: audioFilename,
+            waveformPeaks,
           };
           this.timeline.audioSegments.push(audioSeg);
           this.timeline.audioSegments.sort((a, b) => a.start - b.start);

--- a/js/ltx_director.js
+++ b/js/ltx_director.js
@@ -863,10 +863,22 @@ class TimelineEditor {
     this.audioFileInput.style.display = "none";
     this.audioFileInput.addEventListener("change", (e) => this.handleAudioUpload(e.target.files));
 
+    this.videoFileInput = document.createElement("input");
+    this.videoFileInput.type = "file";
+    this.videoFileInput.accept = "video/*";
+    this.videoFileInput.multiple = true;
+    this.videoFileInput.style.display = "none";
+    this.videoFileInput.addEventListener("change", (e) => this.handleVideoUpload(e.target.files));
+
     const uploadBtn = document.createElement("button");
     uploadBtn.className = "pr-btn";
     uploadBtn.innerHTML = `${ICONS.upload} Add Image`;
     uploadBtn.addEventListener("click", () => this.fileInput.click());
+
+    const uploadVideoBtn = document.createElement("button");
+    uploadVideoBtn.className = "pr-btn";
+    uploadVideoBtn.innerHTML = `${ICONS.play} Add Video`;
+    uploadVideoBtn.addEventListener("click", () => this.videoFileInput.click());
 
     const uploadAudioBtn = document.createElement("button");
     uploadAudioBtn.className = "pr-btn";
@@ -885,7 +897,9 @@ class TimelineEditor {
 
     actionGroup.appendChild(this.fileInput);
     actionGroup.appendChild(this.audioFileInput);
+    actionGroup.appendChild(this.videoFileInput);
     actionGroup.appendChild(uploadBtn);
+    actionGroup.appendChild(uploadVideoBtn);
     actionGroup.appendChild(addTextBtn);
     actionGroup.appendChild(uploadAudioBtn);
     actionGroup.appendChild(deleteBtn);
@@ -1124,15 +1138,19 @@ class TimelineEditor {
       if (e.dataTransfer.files && e.dataTransfer.files.length > 0) {
         const imageFiles = [];
         const audioFiles = [];
+        const videoFiles = [];
         for (let file of e.dataTransfer.files) {
           if (file.type.startsWith("audio/")) audioFiles.push(file);
-          if (file.type.startsWith("image/")) imageFiles.push(file);
+          else if (file.type.startsWith("video/")) videoFiles.push(file);
+          else if (file.type.startsWith("image/")) imageFiles.push(file);
         }
 
         // Let implicit intent handle mixing drops: use the track we hovered over
         // for the first type we process, or fallback.
-        if (audioFiles.length > 0 && (targetTrack === "audio" || imageFiles.length === 0)) {
+        if (audioFiles.length > 0 && (targetTrack === "audio" || (imageFiles.length === 0 && videoFiles.length === 0))) {
           this.handleAudioUpload(audioFiles, targetFrameStart);
+        } else if (videoFiles.length > 0 && imageFiles.length === 0) {
+          this.handleVideoUpload(videoFiles, targetFrameStart);
         } else if (imageFiles.length > 0) {
           this.handleImageUpload(imageFiles, targetFrameStart);
         }
@@ -1614,6 +1632,104 @@ class TimelineEditor {
     this.audioFileInput.value = "";
   }
 
+  // --- Async Video Upload Logic ---
+  // Uploads a video file, calls the backend extraction route, and places a single
+  // "video" segment on the image track whose frames array drives guide_data in execute().
+  async handleVideoUpload(files, targetFrameStart = null) {
+    const frameRate = this.getFrameRate();
+
+    for (let file of files) {
+      if (!file.type.startsWith("video/")) continue;
+
+      try {
+        // 1. Upload the video file to the ComfyUI input directory
+        const uploadBody = new FormData();
+        uploadBody.append("image", file);
+        const uploadResp = await api.fetchApi("/upload/image", { method: "POST", body: uploadBody });
+        if (uploadResp.status !== 200) {
+          console.error("[PromptRelay] Video upload failed:", uploadResp.status);
+          continue;
+        }
+        const uploadData = await uploadResp.json();
+        const subfolder = uploadData.subfolder || "";
+        const videoFile = subfolder ? subfolder + "/" + uploadData.name : uploadData.name;
+
+        // 2. Extract guide frames via backend route
+        const extractResp = await api.fetchApi("/ltx_director/extract_video_frames", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ videoFile, frameRate }),
+        });
+        if (extractResp.status !== 200) {
+          console.error("[PromptRelay] Frame extraction failed:", extractResp.status, await extractResp.text());
+          continue;
+        }
+        const { frames, totalPixelFrames } = await extractResp.json();
+        if (!frames || frames.length === 0) continue;
+
+        const newLength = totalPixelFrames;
+        const currentDuration = this.getVisualDurationFrames();
+
+        // 3. Determine start position
+        let newStart = targetFrameStart;
+        if (newStart === null) {
+          newStart = 0;
+          this.timeline.segments.sort((a, b) => a.start - b.start);
+          for (const existing of this.timeline.segments) {
+            if (newStart + newLength <= existing.start) break;
+            newStart = Math.max(newStart, existing.start + existing.length);
+          }
+        }
+
+        // Grow timeline to accommodate the full clip
+        this.growTimelineIfNeeded(newStart + newLength);
+
+        // 4. Apply center-drag physics to push neighbours (mirrors handleImageUpload)
+        if (targetFrameStart !== null) {
+          const tempId = "TEMP_" + Date.now();
+          this.timeline.segments.push({ id: tempId, start: newStart, length: newLength, type: "temp" });
+          const result = this._applyCenterDragPhysics(this.timeline.segments, tempId, newStart, newStart + newLength / 2, currentDuration, currentDuration, 1);
+          for (const shifted of result) {
+            const orig = this.timeline.segments.find(s => s.id === shifted.id);
+            if (orig) orig.start = shifted.resolvedStart !== undefined ? shifted.resolvedStart : shifted.start;
+          }
+          const tempSeg = this.timeline.segments.find(s => s.id === tempId);
+          newStart = tempSeg.start;
+          this.timeline.segments = this.timeline.segments.filter(s => s.id !== tempId);
+          targetFrameStart = newStart + newLength;
+        }
+
+        // 5. Build the video segment (one segment, all guide frames inside)
+        const seg = {
+          id: Date.now().toString() + Math.random().toString(36).substr(2, 5),
+          start: newStart,
+          length: newLength,
+          type: "video",
+          videoFile,
+          imageB64: frames[0].viewUrl,  // first frame as thumbnail
+          frames,
+          prompt: "",
+          guideStrength: 1.0,
+        };
+
+        // Load thumbnail imgObj for canvas rendering (mirrors handleImageUpload)
+        await new Promise((resolve) => {
+          const img = new Image();
+          img.onload = () => { seg.imgObj = img; resolve(); };
+          img.onerror = () => resolve();
+          img.src = frames[0].viewUrl;
+        });
+
+        this.timeline.segments.push(seg);
+        this.commitChanges();
+
+      } catch (err) {
+        console.error("[PromptRelay] Video upload failed", err);
+      }
+    }
+    if (this.videoFileInput) this.videoFileInput.value = "";
+  }
+
   deleteSelectedSegment() {
     if (this.selectionType === "audio") {
       if (this.timeline.audioSegments.length === 0 || this.selectedIndex === -1) return;
@@ -1861,6 +1977,24 @@ class TimelineEditor {
           }
         }
         this.ctx.restore();
+
+        // --- Filmstrip indicator for video segments ---
+        if (seg.type === "video" && pxWidth > 18) {
+          const fsW = 10, fsH = this.blockHeight - 2;
+          this.ctx.save();
+          this.ctx.beginPath();
+          this.ctx.rect(startX + 1, RULER_HEIGHT + 1, fsW, fsH);
+          this.ctx.clip();
+          this.ctx.fillStyle = "rgba(0,0,0,0.75)";
+          this.ctx.fillRect(startX + 1, RULER_HEIGHT + 1, fsW, fsH);
+          const holeH = 4, holeW = 6;
+          this.ctx.fillStyle = "rgba(255,255,255,0.85)";
+          const holeCount = Math.floor(fsH / (holeH * 2 + 2));
+          for (let k = 0; k < holeCount; k++) {
+            this.ctx.fillRect(startX + 3, RULER_HEIGHT + 1 + k * (holeH * 2 + 2) + 2, holeW, holeH);
+          }
+          this.ctx.restore();
+        }
 
         // --- Prompt subtitle overlay ---
         if (seg.prompt && seg.type !== "ghost" && pxWidth > 24) {
@@ -3163,8 +3297,22 @@ class TimelineEditor {
       fi.click();
     });
 
+    const vidBtn = document.createElement("button");
+    vidBtn.className = "pr-gap-menu-btn";
+    vidBtn.innerHTML = `${ICONS.play} Video Segment`;
+    vidBtn.addEventListener("click", () => {
+      this.dismissGapMenu();
+      const fi = document.createElement("input");
+      fi.type = "file"; fi.accept = "video/*";
+      fi.addEventListener("change", (ev) => {
+        if (ev.target.files?.[0]) this.handleVideoUpload([ev.target.files[0]], gap.frameStart);
+      });
+      fi.click();
+    });
+
     menu.appendChild(textBtn);
     menu.appendChild(imgBtn);
+    menu.appendChild(vidBtn);
     const currentTrack = gap.track === "audio" ? "audio" : "image";
     if (this._copiedSegment && this._copiedSegmentTrack === currentTrack) {
       const pasteBtn = document.createElement("button");

--- a/ltx_director.py
+++ b/ltx_director.py
@@ -626,22 +626,45 @@ class LTXDirector(io.ComfyNode):
                         
                         if latent_samples.numel() == 0:
                             raise ValueError("Encoded audio latent is empty (0 elements).")
-                        
-                        # 2. Create solid mask with value 0.0 (0 means keep/use conditioning, 1 means generate noise)
-                        mask = torch.full(
-                            (1, latent_samples.shape[-2], latent_samples.shape[-1]), 
-                            0.0, 
-                            dtype=torch.float32, 
-                            device=comfy.model_management.intermediate_device()
+
+                        # 2. Per-position noise mask — 0.0 where audio segments cover the
+                        # timeline (keep the encoded audio), 1.0 everywhere else (let the
+                        # model generate audio freely).  A flat 0.0 mask would force the
+                        # model to reproduce silence for uncovered regions, producing no audio
+                        # after the clip ends.
+                        num_audio_latents = latent_samples.shape[-2]
+                        audio_freq = latent_samples.shape[-1]
+                        dev = comfy.model_management.intermediate_device()
+                        mask = torch.ones(
+                            (1, 1, num_audio_latents, audio_freq),
+                            dtype=torch.float32, device=dev,
                         )
-                        
+                        audio_latent_fps = num_audio_latents / (ltxv_length / float(frame_rate))
+                        try:
+                            tdata = json.loads(timeline_data)
+                            for seg in tdata.get("audioSegments", []):
+                                seg_start = float(seg.get("start", 0))
+                                seg_len   = float(seg.get("length", 0))
+                                lat_s = int(seg_start / float(frame_rate) * audio_latent_fps)
+                                lat_e = min(
+                                    int(math.ceil((seg_start + seg_len) / float(frame_rate) * audio_latent_fps)),
+                                    num_audio_latents,
+                                )
+                                if lat_e > lat_s:
+                                    mask[:, :, lat_s:lat_e, :] = 0.0
+                        except Exception:
+                            mask.fill_(0.0)  # fall back to full conditioning
+
                         # 3. Set Latent Noise Mask
                         audio_latent = {
                             "samples": latent_samples,
                             "type": "audio",
-                            "noise_mask": mask.reshape((-1, 1, mask.shape[-2], mask.shape[-1]))
+                            "noise_mask": mask,
                         }
-                        log.info("[PromptRelay] Generated custom audio latent with noise mask (value=0.0).")
+                        log.info(
+                            "[PromptRelay] Custom audio latent: %d/%d latent frames conditioned.",
+                            int((mask == 0.0).all(dim=-1).sum()), num_audio_latents,
+                        )
                     else:
                         raise ValueError("No audio waveform to encode.")
                 except Exception as e:

--- a/ltx_director.py
+++ b/ltx_director.py
@@ -483,8 +483,8 @@ class LTXDirector(io.ComfyNode):
             tdata = json.loads(timeline_data) if timeline_data else {}
             img_segs = [
                 s for s in tdata.get("segments", [])
-                if s.get("type", "image") == "image"
-                and (s.get("imageFile") or s.get("imageB64"))
+                if s.get("type", "image") in ("image", "video")
+                and (s.get("imageFile") or s.get("imageB64") or s.get("frames"))
                 and int(s.get("start", 0)) < duration_frames  # exclude segments fully outside duration
             ]
             img_segs.sort(key=lambda s: s["start"])
@@ -493,46 +493,53 @@ class LTXDirector(io.ComfyNode):
             if guide_strength.strip():
                 strengths = [float(x.strip()) for x in guide_strength.split(",") if x.strip()]
 
-            for idx, seg in enumerate(img_segs):
-                tensor = _load_image_tensor(seg)
+            def snap(val, div):
+                return max(div, (val // div) * div)
 
-                # Apply resize
+            def _process_tensor(tensor):
+                """Resize + compress a [1,H,W,3] tensor using the execute() parameters."""
                 src_h, src_w = tensor.shape[1], tensor.shape[2]
-
-                def snap(val, div):
-                    return max(div, (val // div) * div)
-
                 if custom_width > 0 and custom_height > 0:
-                    # Both dimensions set — apply selected resize_method (pad, crop, stretch, maintain AR)
                     tensor = _resize_image(tensor, custom_width, custom_height, resize_method, divisible_by)
                 elif custom_width > 0:
-                    # Width only — scale height from AR, snap both, then resize to exact dimensions
                     tgt_w = snap(custom_width, divisible_by)
                     tgt_h = snap(int(src_h * tgt_w / src_w), divisible_by)
                     tensor = _resize_image(tensor, tgt_w, tgt_h, "stretch to fit", divisible_by)
                 elif custom_height > 0:
-                    # Height only — scale width from AR, snap both, then resize to exact dimensions
                     tgt_h = snap(custom_height, divisible_by)
                     tgt_w = snap(int(src_w * tgt_h / src_h), divisible_by)
                     tensor = _resize_image(tensor, tgt_w, tgt_h, "stretch to fit", divisible_by)
                 else:
-                    # Both zero — keep original dimensions, just snap to divisible_by
                     tensor = _resize_image(tensor, src_w, src_h, "maintain aspect ratio", divisible_by)
-
-
-                # Apply compression
                 if img_compression > 0:
                     tensor = _compress_image(tensor, img_compression)
+                return tensor
 
-                # Record dimensions of the first processed image for latent generation
-                if idx == 0:
-                    derived_h = tensor.shape[1]
-                    derived_w = tensor.shape[2]
-
+            for idx, seg in enumerate(img_segs):
                 strength = strengths[idx] if idx < len(strengths) else 1.0
-                guide_data["images"].append(tensor)
-                guide_data["insert_frames"].append(int(seg["start"]))
-                guide_data["strengths"].append(float(strength))
+
+                if seg.get("type") == "video":
+                    # Expand one video segment into one guide entry per extracted frame.
+                    # All frames share the segment's single guide_strength value.
+                    for frame in seg.get("frames", []):
+                        abs_frame = int(seg["start"]) + int(frame.get("insertFrame", 0))
+                        if abs_frame >= duration_frames:
+                            continue
+                        tensor = _load_image_tensor(frame)
+                        tensor = _process_tensor(tensor)
+                        if not guide_data["images"]:
+                            derived_h, derived_w = tensor.shape[1], tensor.shape[2]
+                        guide_data["images"].append(tensor)
+                        guide_data["insert_frames"].append(abs_frame)
+                        guide_data["strengths"].append(float(strength))
+                else:
+                    tensor = _load_image_tensor(seg)
+                    tensor = _process_tensor(tensor)
+                    if not guide_data["images"]:
+                        derived_h, derived_w = tensor.shape[1], tensor.shape[2]
+                    guide_data["images"].append(tensor)
+                    guide_data["insert_frames"].append(int(seg["start"]))
+                    guide_data["strengths"].append(float(strength))
             
             # If no images were loaded from the timeline, create a dummy image at strength 0
             # to prevent artifacts in text-to-video mode.

--- a/ltx_director.py
+++ b/ltx_director.py
@@ -409,6 +409,10 @@ class LTXDirector(io.ComfyNode):
                     "use_custom_audio", default=False, optional=True,
                     tooltip="Toggle between using timeline audio (ON) and generating audio from scratch (OFF).",
                 ),
+                io.Float.Input(
+                    "audio_blend_secs", default=1.0, min=0.0, max=10.0, step=0.1, optional=True,
+                    tooltip="Seconds over which the custom audio fades into model-generated audio at each segment boundary. 0 = hard cut.",
+                ),
                 io.String.Input(
                     "local_prompts", multiline=True, default="",
                     tooltip="Auto-populated from the timeline editor.",
@@ -474,7 +478,7 @@ class LTXDirector(io.ComfyNode):
                 frame_rate=24, display_mode="seconds",
                 custom_width=768, custom_height=512, resize_method="maintain aspect ratio",
                 divisible_by=32, img_compression=0, audio_vae=None, optional_latent=None,
-                use_custom_audio=False) -> io.NodeOutput:
+                use_custom_audio=False, audio_blend_secs=1.0) -> io.NodeOutput:
 
         # --- Build guide_data from image segments FIRST (to derive output dimensions) ---
         guide_data = {"images": [], "insert_frames": [], "strengths": [], "frame_rate": frame_rate}
@@ -640,6 +644,7 @@ class LTXDirector(io.ComfyNode):
                             dtype=torch.float32, device=dev,
                         )
                         audio_latent_fps = num_audio_latents / (ltxv_length / float(frame_rate))
+                        blend_frames = max(0, int(round(float(audio_blend_secs) * audio_latent_fps)))
                         try:
                             tdata = json.loads(timeline_data)
                             for seg in tdata.get("audioSegments", []):
@@ -650,8 +655,19 @@ class LTXDirector(io.ComfyNode):
                                     int(math.ceil((seg_start + seg_len) / float(frame_rate) * audio_latent_fps)),
                                     num_audio_latents,
                                 )
-                                if lat_e > lat_s:
-                                    mask[:, :, lat_s:lat_e, :] = 0.0
+                                if lat_e <= lat_s:
+                                    continue
+                                # Fully conditioned core
+                                mask[:, :, lat_s:lat_e, :] = 0.0
+                                # Trailing ramp: taper from 0→1 over the last
+                                # blend_frames positions so the model can blend
+                                # smoothly into freely-generated audio rather
+                                # than cutting hard at the segment boundary.
+                                if blend_frames > 0:
+                                    ramp_s = max(lat_s, lat_e - blend_frames)
+                                    ramp_len = lat_e - ramp_s
+                                    for i in range(ramp_len):
+                                        mask[:, :, ramp_s + i, :] = (i + 1) / (ramp_len + 1)
                         except Exception:
                             mask.fill_(0.0)  # fall back to full conditioning
 

--- a/ltx_director_guide.py
+++ b/ltx_director_guide.py
@@ -1,6 +1,7 @@
 from comfy_extras.nodes_lt import LTXVAddGuide
 import torch
 import comfy.utils
+import comfy.model_management
 from comfy_api.latest import io
 from .ltx_director import GuideData
 
@@ -71,6 +72,15 @@ class LTXDirectorGuide(LTXVAddGuide):
         images = guide_data.get("images", [])
         insert_frames = guide_data.get("insert_frames", [])
         strengths = guide_data.get("strengths", [])
+
+        # Pre-load the VAE onto the compute device once before encoding all guide
+        # frames. Without this, each cls.encode() call triggers load_models_gpu
+        # internally — for a video segment with N latent frames that means N
+        # separate load calls, each with memory-requirement checks and potential
+        # model shuffling.  Loading once here makes subsequent per-frame calls
+        # find the patcher already resident and reduces them to cheap no-ops.
+        if images and hasattr(vae, "patcher"):
+            comfy.model_management.load_models_gpu([vae.patcher])
 
         for idx, img_tensor in enumerate(images):
             f_idx = insert_frames[idx] if idx < len(insert_frames) else 0

--- a/ltx_director_video.py
+++ b/ltx_director_video.py
@@ -1,0 +1,170 @@
+import os
+import re
+import av
+import numpy as np
+import folder_paths
+from pathlib import Path
+from PIL import Image as PILImage
+from server import PromptServer
+from aiohttp import web
+
+_ALLOWED_VIDEO_EXTS = {".mp4", ".mov", ".mkv", ".webm", ".avi", ".m4v"}
+_LTX_TEMPORAL_STRIDE = 8  # LTX VAE compresses time 8× — one guide frame per latent frame
+
+
+@PromptServer.instance.routes.post("/ltx_director/extract_video_frames")
+async def extract_video_frames(request):
+    try:
+        data = await request.json()
+    except Exception:
+        return web.Response(status=400, text="Invalid JSON body")
+
+    video_file = data.get("videoFile", "")
+    try:
+        frame_rate = max(1, int(data.get("frameRate", 24)))
+    except (TypeError, ValueError):
+        return web.Response(status=400, text="Invalid frameRate")
+
+    if not video_file:
+        return web.Response(status=400, text="Missing videoFile")
+
+    # Security: resolve and confirm path stays inside input dir
+    input_dir = folder_paths.get_input_directory()
+    real_input_dir = os.path.realpath(input_dir)
+    real_candidate = os.path.realpath(os.path.join(input_dir, video_file))
+
+    if os.path.commonpath([real_input_dir, real_candidate]) != real_input_dir:
+        return web.Response(status=400, text="Invalid path")
+
+    if os.path.splitext(real_candidate)[1].lower() not in _ALLOWED_VIDEO_EXTS:
+        return web.Response(status=403, text="File type not allowed")
+
+    if not os.path.isfile(real_candidate):
+        return web.Response(status=404, text="File not found")
+
+    # Sanitise subfolder name from video filename stem
+    stem = re.sub(r"[^\w\-.]", "_", Path(real_candidate).stem) or "video"
+
+    out_dir = os.path.join(input_dir, stem)
+    os.makedirs(out_dir, exist_ok=True)
+    real_out_dir = os.path.realpath(out_dir)
+
+    try:
+        container = av.open(real_candidate)
+        if not container.streams.video:
+            container.close()
+            return web.Response(status=422, text="No video stream found")
+
+        video_stream = container.streams.video[0]
+
+        # Determine duration
+        duration_sec = 0.0
+        if video_stream.duration and video_stream.time_base:
+            duration_sec = float(video_stream.duration * video_stream.time_base)
+        if duration_sec <= 0 and container.duration:
+            duration_sec = float(container.duration) / 1_000_000  # AV_TIME_BASE units
+
+        if duration_sec <= 0:
+            container.close()
+            return web.Response(status=422, text="Could not determine video duration")
+
+        total_px = max(1, round(duration_sec * frame_rate))
+        latent_frames = ((total_px - 1) // _LTX_TEMPORAL_STRIDE) + 1
+
+        orig_w = video_stream.codec_context.width
+        orig_h = video_stream.codec_context.height
+
+        # Colorspace detection — mirrors load_video_ui.py to avoid color shift
+        try:
+            from av.video.reformatter import Colorspace, ColorRange
+            src_colorspace = Colorspace.ITU709 if max(orig_w, orig_h) >= 720 else Colorspace.ITU601
+            src_color_range = ColorRange.MPEG
+            dst_range = ColorRange.JPEG
+        except ImportError:
+            src_colorspace = src_color_range = dst_range = None
+
+        if video_stream.codec_context:
+            cc = video_stream.codec_context
+            c_space = getattr(cc, "colorspace", getattr(cc, "color_space", None))
+            if c_space and hasattr(c_space, "name") and c_space.name != "UNSPECIFIED":
+                src_colorspace = c_space
+            c_range = getattr(cc, "color_range", None)
+            if c_range and hasattr(c_range, "name") and c_range.name != "UNSPECIFIED":
+                src_color_range = c_range
+
+        video_stream.thread_type = "AUTO"
+        frames_result = []
+
+        for n in range(latent_frames):
+            target_time = (n * _LTX_TEMPORAL_STRIDE) / float(frame_rate)
+            insert_frame = n * _LTX_TEMPORAL_STRIDE
+
+            # Seek backward to nearest keyframe before target timestamp
+            if video_stream.time_base:
+                seek_pts = int(target_time / float(video_stream.time_base))
+            else:
+                seek_pts = 0
+            try:
+                container.seek(seek_pts, stream=video_stream, backward=True)
+            except av.AVError:
+                container.seek(0, stream=video_stream, backward=True)
+
+            # Decode forward until we reach the target time
+            frame_rgb = None
+            for frame in container.decode(video_stream):
+                frame_time = frame.time
+                if frame_time is None:
+                    if frame.pts is not None and video_stream.time_base:
+                        frame_time = float(frame.pts * float(video_stream.time_base))
+                    else:
+                        frame_time = 0.0
+
+                if frame_time < target_time - (0.5 / frame_rate):
+                    continue  # still before target — keep decoding
+
+                try:
+                    if src_colorspace is not None:
+                        frame_conv = frame.reformat(
+                            format="rgb24",
+                            src_colorspace=src_colorspace,
+                            src_color_range=src_color_range,
+                            dst_color_range=dst_range,
+                        )
+                    else:
+                        frame_conv = frame.reformat(format="rgb24")
+                    frame_rgb = frame_conv.to_ndarray(format="rgb24")
+                except Exception:
+                    frame_rgb = frame.to_ndarray(format="rgb24")
+                break
+
+            if frame_rgb is None:
+                continue
+
+            filename = f"frame_{n:04d}.jpg"
+            out_path = os.path.join(out_dir, filename)
+            real_out_path = os.path.realpath(out_path)
+            if os.path.commonpath([real_out_dir, real_out_path]) != real_out_dir:
+                continue
+
+            PILImage.fromarray(frame_rgb).save(out_path, "JPEG", quality=95)
+
+            view_url = f"/view?filename={filename}&type=input&subfolder={stem}"
+            frames_result.append({
+                "imageFile": f"{stem}/{filename}",
+                "viewUrl": view_url,
+                "insertFrame": insert_frame,
+            })
+
+        container.close()
+
+        if not frames_result:
+            return web.Response(status=422, text="No frames could be extracted")
+
+        return web.json_response({
+            "clipName": stem,
+            "frames": frames_result,
+            "totalPixelFrames": total_px,
+        })
+
+    except Exception as e:
+        return web.Response(status=500, text=f"Extraction failed: {e}")

--- a/ltx_director_video.py
+++ b/ltx_director_video.py
@@ -160,10 +160,63 @@ async def extract_video_frames(request):
         if not frames_result:
             return web.Response(status=422, text="No frames could be extracted")
 
+        # --- Audio extraction ---
+        # Re-open the container for the audio pass so we don't have to manage
+        # interleaved seek state between video and audio streams.
+        audio_file_rel = None
+        try:
+            audio_container = av.open(real_candidate)
+            if audio_container.streams.audio:
+                audio_stream = audio_container.streams.audio[0]
+                audio_stream.thread_type = "AUTO"
+                resampler = av.AudioResampler(format="fltp", layout="stereo", rate=44100)
+
+                chunks = []
+                for frame in audio_container.decode(audio_stream):
+                    for rf in resampler.resample(frame):
+                        chunks.append(rf.to_ndarray())  # [2, N] float32
+
+                # Flush resampler
+                for rf in resampler.resample(None):
+                    chunks.append(rf.to_ndarray())
+
+                if chunks:
+                    import numpy as _np
+                    waveform = _np.concatenate(chunks, axis=1)  # [2, total_samples]
+
+                    audio_filename = f"{stem}.wav"
+                    audio_path = os.path.join(out_dir, audio_filename)
+                    real_audio_path = os.path.realpath(audio_path)
+                    if os.path.commonpath([real_out_dir, real_audio_path]) == real_out_dir:
+                        # Write WAV with wave module (always available, no extra deps)
+                        import wave as _wave
+                        import struct as _struct
+                        channels = waveform.shape[0]
+                        total_samples = waveform.shape[1]
+                        sample_rate = 44100
+                        # Interleave channels and convert to int16
+                        interleaved = waveform.T.reshape(-1)  # [total_samples * channels]
+                        # Clamp and convert float32 → int16
+                        interleaved = _np.clip(interleaved, -1.0, 1.0)
+                        pcm = (interleaved * 32767).astype(_np.int16)
+                        with _wave.open(audio_path, "wb") as wf:
+                            wf.setnchannels(channels)
+                            wf.setsampwidth(2)  # int16 = 2 bytes
+                            wf.setframerate(sample_rate)
+                            wf.writeframes(pcm.tobytes())
+
+                        audio_file_rel = f"{stem}/{audio_filename}"
+            audio_container.close()
+        except Exception as e:
+            # Audio extraction is best-effort — don't fail the whole request
+            import logging as _log
+            _log.getLogger(__name__).warning("[LTXDirectorVideo] Audio extraction skipped: %s", e)
+
         return web.json_response({
             "clipName": stem,
             "frames": frames_result,
             "totalPixelFrames": total_px,
+            "audioFile": audio_file_rel,  # None if video has no audio or extraction failed
         })
 
     except Exception as e:


### PR DESCRIPTION
## Summary

- Adds video import to the LTX Director timeline editor: drag-and-drop or toolbar button extracts one JPEG per LTX latent frame (every 8 pixel frames) into `input/<clip_stem>/`, placing a single `type:\"video\"` segment on the image track with a filmstrip indicator
- Co-imports audio alongside the video frames; waveform peaks are computed via the Web Audio API so the audio segment renders correctly
- Extends `LTXDirector.execute()` to expand video segments into per-latent-frame guide entries, each at its correct pixel-space insert position
- Fixes Custom Audio guide masking: mask is now `1.0` (generate freely) everywhere except latent positions covered by audio segments (`0.0`), with a configurable trailing ramp (`audio_blend_secs`, default 1 s) that fades the preserved audio into model-generated audio rather than cutting hard at the boundary
- Pre-loads the VAE patcher once before the guide encode loop to reduce `load_models_gpu` call overhead for video segments with many latent frames

## New files

- `ltx_director_video.py` — `POST /ltx_director/extract_video_frames` route; PyAV frame extraction with colorspace correction + stereo WAV audio export

## New node input

- `audio_blend_secs` (Float, default 1.0, max 60.0) on `LTXDirector` — controls the trailing-edge ramp duration on the Custom Audio noise mask

## Test plan

- [ ] Drop a `.mp4` onto the image track → single video segment appears spanning clip duration with filmstrip thumbnail
- [ ] Check `input/<clip_stem>/` for `frame_NNN.jpg` files; count should equal `((total_px-1)//8)+1`
- [ ] Confirm audio waveform renders on the co-imported audio segment
- [ ] Queue a generation with Custom Audio enabled — audio from the clip is preserved; silence beyond the clip is replaced by model-generated audio
- [ ] Adjust `audio_blend_secs` to 0 (hard cut) and verify audible difference vs default
- [ ] Test toolbar "Add Video" button and right-click gap → "Video Segment"
- [ ] Confirm existing image and text segments are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)