### PR TITLE
Updated speech length calculator Regex, now only supports double quotes

### DIFF
--- a/speech_length_calculator.py
+++ b/speech_length_calculator.py
@@ -27,7 +27,7 @@ class SpeechLengthCalculator:
         active_text = text_input if (text_input is not None and isinstance(text_input, str) and text_input.strip() != "") else text
         
         # Regex to find words inside double quotes, single quotes, or smart quotes
-        matches = re.findall(r'"([^"]*)"|\'([^\']*)\'|“([^”]*)”|‘([^’]*)’', active_text)
+        matches = re.findall(r'"([^"]*)"|“([^”]*)”', active_text)
         
         # Extract matches, handling all possible captured groups from the regex
         quoted_text = " ".join([next((g for g in m if g), "") for m in matches])


### PR DESCRIPTION
I noticed a bug when using the speech length calculator node (which I appreciate you making btw). 

When using the existing regex the following text input will calculate 14 words when it should actually only calculate 10 words:

He'll regret his decision to speak later, but nevertheless he said "You're such a good swimmer!" She replied "You're not so bad yourself."

I've updated the regex to now only support double quotes.