### PR TITLE
feat(director): IC-LoRA track accepts a still image, looped to fill its span

### DIFF
--- a/js/ltx_director.js
+++ b/js/ltx_director.js
@@ -2210,7 +2210,7 @@ class TimelineEditor {
 
     this.motionFileInput = document.createElement("input");
     this.motionFileInput.type = "file";
-    this.motionFileInput.accept = "video/*";
+    this.motionFileInput.accept = "video/*,image/*";
     this.motionFileInput.multiple = true;
     this.motionFileInput.style.display = "none";
     this.motionFileInput.addEventListener("change", (e) => this.handleMotionUpload(e.target.files));
@@ -4430,7 +4430,96 @@ class TimelineEditor {
     const frameRate = this.getFrameRate();
 
     for (let file of files) {
-      if (!(file.type.startsWith("video/") || file.name.toLowerCase().match(/\.(mp4|webm|mkv|avi|mov|m4v|flv|wmv)$/))) continue;
+      const isImageRef = file.type.startsWith("image/") || !!file.name.toLowerCase().match(/\.(png|jpe?g|webp|bmp|gif)$/);
+      const isVideo = file.type.startsWith("video/") || !!file.name.toLowerCase().match(/\.(mp4|webm|mkv|avi|mov|m4v|flv|wmv)$/);
+      if (!isImageRef && !isVideo) continue;
+
+      if (isImageRef) {
+        // Static IC reference image (e.g. the Ingredients IC-LoRA): add a motion segment
+        // that loops this single still across its span. The backend loads the image and
+        // repeats it to the segment length, so it behaves like a looped static video —
+        // which is exactly what the official IC-LoRA pipeline does with a reference sheet.
+        await new Promise((resolve) => {
+          try {
+            const blobUrl = URL.createObjectURL(file);
+            const img = new Image();
+            img.onerror = () => { console.error("[LTXDirector] IC image load error"); URL.revokeObjectURL(blobUrl); resolve(); };
+            img.onload = () => {
+              // Default span = the whole output, since a reference sheet conditions the
+              // entire clip. The user can resize the segment afterwards.
+              let newLength = Math.max(1, this.getDurationFrames());
+              let newStart = targetFrameStart;
+              if (newStart === null) {
+                newStart = 0;
+                this.timeline.motionSegments.sort((a, b) => a.start - b.start);
+                for (let i = 0; i < this.timeline.motionSegments.length; i++) {
+                  let s = this.timeline.motionSegments[i];
+                  if (newStart + newLength <= s.start) break;
+                  newStart = Math.max(newStart, s.start + s.length);
+                }
+              }
+
+              let imageB64 = "";
+              try {
+                const canvas = document.createElement('canvas');
+                canvas.width = Math.min(img.naturalWidth, 512) || 512;
+                canvas.height = Math.round((img.naturalHeight / img.naturalWidth) * canvas.width) || 512;
+                const ctx = canvas.getContext('2d');
+                ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
+                imageB64 = canvas.toDataURL('image/jpeg');
+              } catch (e) { /* cosmetic: fall back to no persisted thumbnail */ }
+
+              const seg = {
+                id: Date.now().toString() + Math.random().toString(36).substr(2, 5),
+                type: "motion_video",
+                start: newStart,
+                length: newLength,
+                trimStart: 0,
+                videoDurationFrames: newLength,
+                videoFile: "",        // filled once upload completes (image path)
+                isStaticRef: true,    // metadata; backend also detects by extension
+                fileName: file.name,
+                videoStrength: 1.0,
+                videoAttentionStrength: 0.65,
+                resampleMode: "nearest",
+                imageB64: imageB64,
+                imgObj: img,
+                _uploading: true,
+                _blobUrl: blobUrl,
+                fileSize: file.size
+              };
+
+              this.timeline.motionSegments.push(seg);
+              this.timeline.motionSegments.sort((a, b) => a.start - b.start);
+              if (!this.retakeMode) this.growTimelineIfNeeded(seg.start + seg.length);
+              this.selectionType = "motion";
+              this.selectedIndex = this.timeline.motionSegments.findIndex(s => s.id === seg.id);
+              this.updateUIFromSelection();
+              this.commitChanges(true);
+              this.render();
+              resolve();
+
+              this._uploadVideoFile(file).then(filePath => {
+                for (let s of this.timeline.motionSegments) {
+                  if (s._blobUrl === blobUrl || s.id === seg.id) { s.videoFile = filePath; s._uploading = false; }
+                }
+                this.commitChanges(true);
+                this.render();
+              }).catch(err => {
+                console.error("[LTXDirector] Background IC image upload failed", err);
+                const s = this.timeline.motionSegments.find(s => s.id === seg.id);
+                if (s) s._uploading = false;
+                this.render();
+              });
+            };
+            img.src = blobUrl;
+          } catch (err) {
+            console.error("[LTXDirector] IC image processing failed", err);
+            resolve();
+          }
+        });
+        continue;
+      }
 
       await new Promise(async (resolve) => {
         try {

--- a/js/ltx_director.js
+++ b/js/ltx_director.js
@@ -2038,7 +2038,7 @@ class TimelineEditor {
           seg.imgObj.onload = () => { if (!this._isDragging) this.render(); };
           seg.imgObj.src = seg.imageB64;
         }
-        if (seg.type === "motion_video") {
+        if (seg.type === "motion_video" && !seg.isStaticRef) {
           this._ensureVideoEl(seg);
           this._ensureThumbnails(seg);
           if (isOverrideAudio) {
@@ -3078,7 +3078,11 @@ class TimelineEditor {
         } else if (audioFiles.length > 0 && (targetTrack === "audio" || imageFiles.length === 0)) {
           this.handleAudioUpload(audioFiles, targetFrameStart);
         } else if (imageFiles.length > 0) {
-          this.handleImageUpload(imageFiles, targetFrameStart);
+          if (targetTrack === "motion") {
+            this.handleMotionUpload(imageFiles, targetFrameStart);
+          } else {
+            this.handleImageUpload(imageFiles, targetFrameStart);
+          }
         }
       }
     });
@@ -4446,18 +4450,11 @@ class TimelineEditor {
             img.onerror = () => { console.error("[LTXDirector] IC image load error"); URL.revokeObjectURL(blobUrl); resolve(); };
             img.onload = () => {
               // Default span = the whole output, since a reference sheet conditions the
-              // entire clip. The user can resize the segment afterwards.
+              // entire clip. It's meant to overlap the timeline, not be appended after
+              // existing clips — so default to start 0 rather than auto-placing past
+              // them (which would silently grow the render length). User can move it.
               let newLength = Math.max(1, this.getDurationFrames());
-              let newStart = targetFrameStart;
-              if (newStart === null) {
-                newStart = 0;
-                this.timeline.motionSegments.sort((a, b) => a.start - b.start);
-                for (let i = 0; i < this.timeline.motionSegments.length; i++) {
-                  let s = this.timeline.motionSegments[i];
-                  if (newStart + newLength <= s.start) break;
-                  newStart = Math.max(newStart, s.start + s.length);
-                }
-              }
+              let newStart = (targetFrameStart !== null) ? targetFrameStart : 0;
 
               let imageB64 = "";
               try {
@@ -9176,7 +9173,7 @@ class TimelineEditor {
   promptAddMotionInGap(frameStart, frameEnd) {
     const fi = document.createElement("input");
     fi.type = "file";
-    fi.accept = "video/*";
+    fi.accept = "video/*,image/*";
     fi.addEventListener("change", (ev) => {
       if (ev.target.files?.[0]) this.handleMotionUpload([ev.target.files[0]], frameStart);
     });

--- a/ltx_director_guide.py
+++ b/ltx_director_guide.py
@@ -220,9 +220,18 @@ def _load_motion_video_frames(video_file, trim_start_frames, length_frames, dire
     # reference sheet into a static video. Trim/seek don't apply to a still — the existing
     # ResampleGuideFrames repeats a 1-frame source to the target count.
     if os.path.splitext(path)[1].lower() in (".png", ".jpg", ".jpeg", ".webp", ".bmp", ".gif"):
-        from PIL import Image as _PILImage
+        from PIL import Image as _PILImage, ImageOps as _ImageOps
         with _PILImage.open(path) as _im:
-            arr = np.asarray(_im.convert("RGB"), dtype=np.float32) / 255.0
+            if getattr(_im, "n_frames", 1) > 1:
+                log.warning(f"[LTXDirectorGuide] {path} has {_im.n_frames} frames; using only the first as a static IC reference")
+            # Respect EXIF orientation (phone/camera exports) so the reference isn't sideways.
+            _im = _ImageOps.exif_transpose(_im)
+            # Composite transparency onto white instead of letting convert('RGB') flatten it to black.
+            if _im.mode in ("RGBA", "LA", "P"):
+                _im = _im.convert("RGBA")
+                _bg = _PILImage.new("RGBA", _im.size, (255, 255, 255, 255))
+                _im = _PILImage.alpha_composite(_bg, _im)
+            arr = np.clip(np.asarray(_im.convert("RGB"), dtype=np.float32) / 255.0, 0.0, 1.0)
         single = torch.from_numpy(arr).unsqueeze(0)  # [1, H, W, 3]
         target_count = max(1, int(round(float(length_frames))))
         log.info(f"[LTXDirectorGuide] Static IC reference image {path} looped to {target_count} frames")

--- a/ltx_director_guide.py
+++ b/ltx_director_guide.py
@@ -214,6 +214,20 @@ class ResampleGuideFrames:
 def _load_motion_video_frames(video_file, trim_start_frames, length_frames, director_fps, resample_mode="nearest"):
     path = _resolve_input_video_path(video_file)
     target_fps = max(1.0, float(director_fps))
+
+    # Static-image IC reference (e.g. the Ingredients IC-LoRA): load the single still and
+    # loop it to fill the segment length, mirroring how the official pipeline turns a
+    # reference sheet into a static video. Trim/seek don't apply to a still — the existing
+    # ResampleGuideFrames repeats a 1-frame source to the target count.
+    if os.path.splitext(path)[1].lower() in (".png", ".jpg", ".jpeg", ".webp", ".bmp", ".gif"):
+        from PIL import Image as _PILImage
+        with _PILImage.open(path) as _im:
+            arr = np.asarray(_im.convert("RGB"), dtype=np.float32) / 255.0
+        single = torch.from_numpy(arr).unsqueeze(0)  # [1, H, W, 3]
+        target_count = max(1, int(round(float(length_frames))))
+        log.info(f"[LTXDirectorGuide] Static IC reference image {path} looped to {target_count} frames")
+        return ResampleGuideFrames().execute(single, target_fps, target_fps, target_count, resample_mode)
+
     start_s = max(0.0, float(trim_start_frames) / target_fps)
     dur_s = max(0.0, float(length_frames) / target_fps)
     end_s = start_s + dur_s if dur_s > 0 else None


### PR DESCRIPTION
## What
Lets the **IC-LoRA Video track** accept a still **image**, not just video. The image is looped across the segment to act as a static reference — which is exactly how image-conditioned IC-LoRAs (e.g. the LTX-2.3 *Ingredients* IC-LoRA) expect their reference sheet: a single composite still fed as a static video at output resolution.

## Why
The Ingredients / reference-sheet IC-LoRAs condition on one composite image (characters, props, location). Previously the IC track hard-filtered to video, so there was no way to feed them through the Director.

## How
- **Frontend** (`js/ltx_director.js`): the IC track input (toolbar + in-lane `+` + gap-add + drag-drop onto the lane) now accepts `image/*`. Dropping/adding an image builds a motion segment (`type: motion_video`, `isStaticRef: true`) defaulting to the full output span (start 0, so it overlaps rather than extends the render).
- **Backend** (`ltx_director_guide.py`): `_load_motion_video_frames` detects an image path, loads it as one frame, and the existing `ResampleGuideFrames` repeats it to the segment length — so it flows through the unchanged encode → `append_keyframe` → attention path. Reference downscale factor is honoured as before (Ingredients = 1, no dilation).
- Image loading respects EXIF orientation, composites transparency onto white, warns on multi-frame GIF/WebP, and clips pixels to [0,1].

## Notes
- The looping primitive (`ResampleGuideFrames` repeating a 1-frame source) already existed; this wires an image into it.
- Prompt format for these LoRAs is two-part: `Reference sheet: …` / `Generated video: …`.

Files: `js/ltx_director.js`, `ltx_director_guide.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)