### PR TITLE
Fix: enable spellcheck on Director Global Prompt field

### DIFF
--- a/js/ltx_director.js
+++ b/js/ltx_director.js
@@ -2756,7 +2756,6 @@ class TimelineEditor {
     this.globalPromptInput = document.createElement("textarea");
     this.globalPromptInput.className = "pr-prompt-area";
     this.globalPromptInput.placeholder = "Enter global prompt here...";
-    this.globalPromptInput.spellcheck = false;
     globalPromptWrapper.appendChild(this.globalPromptInput);
 
     this.globalPromptInput.addEventListener("focus", () => {

--- a/js/ltx_director.js
+++ b/js/ltx_director.js
@@ -2758,6 +2758,7 @@ class TimelineEditor {
     this.globalPromptInput.placeholder = "Enter global prompt here...";
     globalPromptWrapper.appendChild(this.globalPromptInput);
 
+    this.globalPromptInput.addEventListener("contextmenu", (e) => e.stopPropagation());
     this.globalPromptInput.addEventListener("focus", () => {
       globalPromptWrapper.classList.add("focus-active");
       this.wrapper.classList.add("has-focus");
@@ -2916,6 +2917,7 @@ class TimelineEditor {
     this.promptInput.style.opacity = "0.4";
     this.promptWrapper.appendChild(this.promptInput);
 
+    this.promptInput.addEventListener("contextmenu", (e) => e.stopPropagation());
     this.promptInput.addEventListener("focus", () => {
       this.promptWrapper.classList.add("focus-active");
       this.wrapper.classList.add("has-focus");


### PR DESCRIPTION
## Summary
- The **Global Prompt** textarea in the LTX Director node explicitly set `spellcheck = false` (introduced in the LTX Director 2.0 Update). The **Segment Prompt** textarea has no such override, so it's inconsistent — looks like an unintentional oversight.
- Right-clicking inside either prompt textarea let the `contextmenu` event bubble up and get intercepted by the node/canvas context menu, instead of showing the browser's native text context menu — so spellcheck-corrected words couldn't be applied via right-click, unlike core ComfyUI text widgets.

This PR:
1. Removes `spellcheck = false` from the Global Prompt textarea.
2. Stops `contextmenu` propagation on both prompt textareas so the browser's native context menu (with spellcheck suggestions) shows instead of the node's context menu.

## Test plan
- [ ] Open the LTX Director node in ComfyUI
- [ ] Type a misspelled word into the Global Prompt field, confirm the browser underlines it
- [ ] Right-click the misspelled word in both the Global Prompt and Segment Prompt fields, confirm the native browser context menu appears with spelling suggestions (not the node's context menu)
- [ ] Confirm normal node right-click context menu (on the timeline/canvas) still works as before
