### PR TITLE
Implement middle-click drag panning and wheel events passthrough for UI elements

### DIFF
--- a/js/load_audio_ui.js
+++ b/js/load_audio_ui.js
@@ -1,3 +1,5 @@
+import { addMiddleClickPan, addWheelPassthrough } from './utility.js';
+
 import { app } from "../../scripts/app.js";
 import { api } from "../../scripts/api.js";
 
@@ -149,6 +151,10 @@ app.registerExtension({
 
                 // 1. Build the Main Custom HTML Container
                 const container = document.createElement("div");
+
+                addMiddleClickPan(container);
+                addWheelPassthrough(container);
+
                 const defaultBg = "rgba(30, 30, 30, 0.9)";
                 Object.assign(container.style, {
                     display: "flex",

--- a/js/load_video_ui.js
+++ b/js/load_video_ui.js
@@ -1,3 +1,5 @@
+import { addMiddleClickPan, addWheelPassthrough } from './utility.js';
+
 import { app } from "../../scripts/app.js";
 import { api } from "../../scripts/api.js";
 
@@ -443,6 +445,10 @@ app.registerExtension({
                 // UI CONTAINER (Preview & Timeline Editor)
                 // ====================================================================
                 const container = document.createElement("div");
+
+                addMiddleClickPan(container);
+                addWheelPassthrough(container);
+
                 const defaultBg = "rgba(30, 30, 30, 0.9)";
                 Object.assign(container.style, {
                     display: "flex",

--- a/js/ltx_director.js
+++ b/js/ltx_director.js
@@ -1,3 +1,5 @@
+import { addMiddleClickPan, addWheelPassthrough, addWheelPassthroughPrompt } from './utility.js';
+
 const { app } = window.comfyAPI.app;
 const { api } = window.comfyAPI.api;
 
@@ -2762,6 +2764,9 @@ class TimelineEditor {
     this.globalPromptInput.spellcheck = false;
     globalPromptWrapper.appendChild(this.globalPromptInput);
 
+    this.globalPromptInput.addEventListener("wheel", (e) => e.stopPropagation());
+    addWheelPassthroughPrompt(this.globalPromptInput);
+
     this.globalPromptInput.addEventListener("focus", () => {
       globalPromptWrapper.classList.add("focus-active");
       this.wrapper.classList.add("has-focus");
@@ -2919,6 +2924,9 @@ class TimelineEditor {
     this.promptInput.placeholder = "No segment selected!";
     this.promptInput.style.opacity = "0.4";
     this.promptWrapper.appendChild(this.promptInput);
+
+    this.promptInput.addEventListener("wheel", (e) => e.stopPropagation());
+    addWheelPassthroughPrompt(this.promptInput);
 
     this.promptInput.addEventListener("focus", () => {
       this.promptWrapper.classList.add("focus-active");
@@ -3748,6 +3756,9 @@ class TimelineEditor {
     this.wrapper.appendChild(this.globalPropContainer);
 
     this.container.appendChild(this.wrapper);
+
+    addMiddleClickPan(this.wrapper);
+    addWheelPassthrough(this.wrapper);
   }
 
   syncWidgetsAndUI() {

--- a/js/multi_image_loader.js
+++ b/js/multi_image_loader.js
@@ -1,3 +1,5 @@
+import { addMiddleClickPan, addWheelPassthrough } from './utility.js';
+
 import { app } from "../../scripts/app.js";
 import { api } from "../../scripts/api.js";
 
@@ -118,6 +120,9 @@ app.registerExtension({
             const nodeWidth = node.size?.[0] || width || 220;
             return [Math.max(10, nodeWidth - 30), requiredGalleryHeight];
         };
+
+        addMiddleClickPan(container);
+        addWheelPassthrough(container);
 
         // --- SAFELY HIDE THE IMAGE_PATHS WIDGET ---
         const pathsWidget = node.widgets.find(w => w.name === "image_paths");

--- a/js/speech_length_calculator.js
+++ b/js/speech_length_calculator.js
@@ -1,3 +1,5 @@
+import { addMiddleClickPan, addWheelPassthrough } from './utility.js';
+
 import { app } from "../../scripts/app.js";
 import { ComfyWidgets } from "../../scripts/widgets.js";
 
@@ -190,6 +192,9 @@ app.registerExtension({
                         }
                     }
                 }
+
+                addMiddleClickPan(uiContainer);
+                addWheelPassthrough(uiContainer);
 
                 // Tell LiteGraph exactly how much vertical space to hold for our UI
                 statsWidget.computeSize = function() {

--- a/js/utility.js
+++ b/js/utility.js
@@ -1,0 +1,71 @@
+const { app } = window.comfyAPI.app;
+
+// Helper to forward wheel events to the LiteGraph canvas
+function forwardWheelToCanvas(e) {
+  const canvas = app.canvas?.canvas;
+  if (canvas) {
+    canvas.dispatchEvent(new WheelEvent(e.type, e));
+    e.preventDefault();
+  }
+}
+
+// Based on https://github.com/kijai/ComfyUI-KJNodes/blob/main/web/js/utility.js
+// ─── Middle-click pan passthrough for DOM widgets ───
+// Allows panning the LiteGraph canvas via middle-click drag on any DOM element
+export function addMiddleClickPan(element) {
+  const onMouseDown = (e) => {
+    if (e.button !== 1) return;
+    const ds = app.canvas?.ds;
+    if (!ds) return;
+
+    e.preventDefault();
+    const startX = e.clientX;
+    const startY = e.clientY;
+    const [startOffsetX, startOffsetY] = ds.offset;
+    const scale = ds.scale; // Capture the canvas zoom factor at the start of dragging
+
+    const onMove = (me) => {
+      // Divide pixel delta by the scale to keep panning rate 1:1 with the cursor
+      ds.offset[0] = startOffsetX + (me.clientX - startX) / scale;
+      ds.offset[1] = startOffsetY + (me.clientY - startY) / scale;
+      app.canvas.setDirty(true, true);
+    };
+
+    const onUp = () => {
+      document.removeEventListener('mousemove', onMove);
+      document.removeEventListener('mouseup', onUp);
+    };
+
+    document.addEventListener('mousemove', onMove);
+    document.addEventListener('mouseup', onUp);
+  };
+
+  element.addEventListener('mousedown', onMouseDown);
+  return () => element.removeEventListener('mousedown', onMouseDown);
+}
+
+// ─── Wheel zoom passthrough for DOM widgets ───
+// Re-dispatches wheel events to the LiteGraph canvas for zoom
+export function addWheelPassthrough(element) {
+  element.addEventListener('wheel', (e) => {
+    if (e.shiftKey) return e.stopPropagation();
+    forwardWheelToCanvas(e);
+  }, { passive: false });
+}
+
+// ─── Wheel zoom passthrough for prompt inputs ───
+export function addWheelPassthroughPrompt(element) {
+  element.addEventListener('wheel', (e) => {
+    if (e.ctrlKey || e.metaKey) {
+      e.preventDefault();
+      e.stopPropagation();
+      app.canvas?.processMouseWheel(e);
+      return;
+    }
+
+    const canScrollY = element.scrollHeight > element.clientHeight;
+    if (!canScrollY) {
+      forwardWheelToCanvas(e);
+    }
+  }, { passive: false });
+}


### PR DESCRIPTION
Custom DOM-based UI elements (audio/video loaders, multi-image gallery, director timeline, speech calculator) were blocking middle-click panning and mouse-wheel zoom on the LiteGraph canvas. This adds a small utility module that forwards those events to the canvas so navigation works consistently regardless of what element you're hovering.

### Why this matters:

Previously, hovering over any custom UI panel meant you couldn't pan/zoom the graph without moving the mouse to empty canvas space. Now navigation works everywhere, which is a noticeable UX improvement for complex workflows.

### Changes:

- **js/utility.js** (new) — three helpers:
  - `addMiddleClickPan(element)` — enables middle-click drag panning on any element
  - `addWheelPassthrough(element)` — forwards wheel events to canvas for zoom (shift+wheel still propagates normally)
  - `addWheelPassthroughPrompt(element)` — specialized version for text inputs: allows Ctrl/Cmd+wheel zoom while preserving internal scrolling when content overflows

- **Integration** across 5 components:
  - `load_audio_ui.js` — container
  - `load_video_ui.js` — container  
  - `ltx_director.js` — timeline wrapper + global/shot prompt inputs (uses prompt-specific helper)
  - `multi_image_loader.js` — container
  - `speech_length_calculator.js` — container


https://github.com/user-attachments/assets/087793a4-b705-46b5-9b4b-7a335d1c8256


https://github.com/user-attachments/assets/64cacbeb-6db4-4dbd-aac0-df5dfe1ad595

